### PR TITLE
Update API documentation link on Getting Started tutorial page

### DIFF
--- a/content/docs/3-getting-started.md
+++ b/content/docs/3-getting-started.md
@@ -344,7 +344,7 @@ This will make all functions defined in the `Nanoc::Helpers::Tagging` module ava
 
 Now compile the site again, and you’ll see that nanoc shows the tags for the page, but this time using the built-in tagging helper.
 
-nanoc comes with quite a few useful helpers. The [API documentation](/docs/api/3.2/) describes each one of them.
+nanoc comes with quite a few useful helpers. The [API documentation](/docs/api/3.4/) describes each one of them.
 
 That’s it!
 ----------


### PR DESCRIPTION
The API documentation link went to the docs for 3.2, not the most recent 3.4. I updated this link.
