### PR TITLE
Removed .hgignore file

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,7 +1,0 @@
-syntax: glob
-.DS_Store
-output.diff
-*.tmproj
-tmp
-output
-.sass-cache


### PR DESCRIPTION
Was there a reason it was still being included? .hgignore is Mercurial only correct?
