### PR TITLE
Improve admonition icons

### DIFF
--- a/content/assets/style/_color.scss
+++ b/content/assets/style/_color.scss
@@ -108,7 +108,7 @@ div.admonition-wrapper:before {
 }
 
 div.admonition-wrapper.tip:before {
-    background-color: adjust-hue($link-color-a, 240deg);
+    background-color: $link-color-a;
 }
 
 div.admonition-wrapper.note:before {

--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -112,15 +112,15 @@ div.admonition-wrapper .admonition {
 }
 
 div.admonition-wrapper.tip:before {
-    content: "\1F4A1";
+    content: "\1F393";
 }
 
 div.admonition-wrapper.note:before {
-    content: "\2139";
+    content: "\270E";
 }
 
 div.admonition-wrapper.caution:before {
-    content: "\26A1";
+    content: "\26A0";
 }
 
 // SPECIAL STYLING


### PR DESCRIPTION
This changes the admonition icons to the following:
- Notes are indicated with a pencil.
- Tips are indicated with an academic cap.
- Cautions are indicated with a danger sign sign.

In addition, I replaced the green background for tips with a blue one, to prevent a new color from being introduced and so that only cautions stand out more. (I tried playing with more subtle variations, including ones with a white background, but they didn’t work out well.)

Compare old and new:

![new-admonition-icons](https://cloud.githubusercontent.com/assets/6269/2595696/9b310992-ba9d-11e3-81b3-c07da49106cf.png)
