### PR TITLE
Improve H2 and H3 header style

### DIFF
--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -368,7 +368,7 @@ body.page .content {
             }
 
             h2 {
-                font-size: 20px;
+                font-size: 24px;
                 font-weight: normal;
             }
 
@@ -377,11 +377,8 @@ body.page .content {
             }
 
             h3 {
-                font-size: 15px;
+                font-size: 18px;
                 font-weight: normal;
-
-                letter-spacing: 1px;
-                text-transform: uppercase;
 
                 margin-top: 40px;
             }


### PR DESCRIPTION
The all-uppercase H3s have been annoying me for a while. This PR changes the styling of H2 and H3 to be more standard, using the sizes 24px and 18px.

Before:

![before](https://cloud.githubusercontent.com/assets/6269/2753189/cab25620-c92b-11e3-896e-5a4b23667f5c.png)

After:

![after](https://cloud.githubusercontent.com/assets/6269/2753188/ca87fd76-c92b-11e3-93e9-7b1fba02dc31.png)
