### PR TITLE
Add Homebrew to Ruby install options for OS X

### DIFF
--- a/content/install.md
+++ b/content/install.md
@@ -25,7 +25,7 @@ Ruby may already be installed on your system. To check, open a terminal window a
 <kbd>ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-darwin13.0]</kbd>
 <span class="prompt">%</span> </pre>
 
-To install Ruby, you have a few different options. You can use your operating system’s package manager, e.g. <kbd>sudo apt-get install ruby1.9.1</kbd> on Debian and Ubuntu, or <kbd>sudo pacman -S ruby</kbd> on Arch Linux. On Windows, you can use [RubyInstaller](http://rubyinstaller.org/). On Unix-like operating systems, [chruby](https://github.com/postmodern/chruby), [rbenv](http://rbenv.org/) or [rvm](http://rvm.io/) are a good choice. Alternatively, you can [download the Ruby source code](https://www.ruby-lang.org/en/downloads/) and compile it yourself.
+To install Ruby, you have a few different options. You can use your operating system’s package manager, e.g. <kbd>sudo apt-get install ruby1.9.1</kbd> on Debian and Ubuntu, or <kbd>sudo pacman -S ruby</kbd> on Arch Linux. On Windows, you can use [RubyInstaller](http://rubyinstaller.org/). For OS X, [Homebrew](http://brew.sh/) is a reliable package manager - you'll need to install the OS X Developer Tools too. On other Unix-like operating systems, [chruby](https://github.com/postmodern/chruby), [rbenv](http://rbenv.org/) or [rvm](http://rvm.io/) are a good choice. Alternatively, you can [download the Ruby source code](https://www.ruby-lang.org/en/downloads/) and compile it yourself.
 
 Installing RubyGems
 -------------------


### PR DESCRIPTION
Homebrew seems to have become the favourite over Macports or Fink, and will simply do `brew install ruby`.
