### PR TITLE
Document :mtime item attribute on website

### DIFF
--- a/content/docs/basics.md
+++ b/content/docs/basics.md
@@ -138,17 +138,17 @@ title: "Some Page"
 
 If you are using the default data source (`filesystem_unified`), then each item will automatically receive some extra attributes that may be useful. These are:
 
-`:filename`
-: the name of the file corresponding to the item (if there is only one file that contains both content and metadata)
-
 `:content_filename`
 : the name of the content file (if there is a content file)
 
-`:meta_filename`
-: the name of the meta-file (if there is a meta-file)
-
 `:extension`
 : the extension of the file or the content file (if there is one, because it is possible to have a meta-file without a corresponding content file)
+
+`:filename`
+: the name of the file corresponding to the item (if there is only one file that contains both content and metadata)
+
+`:meta_filename`
+: the name of the meta-file (if there is a meta-file)
 
 `:mtime`
 : the time when the item was last modified


### PR DESCRIPTION
I recently found the `item[:mtime]` attribute to be helpful. It is mentioned in the API documentation, but not on the website with the other attributes available from the default data source. Commit `d064caf` adds it to the list in `basic.md` so that it is easier to find.

The other commit alphabetizes the list -- I'm not sure if that is desirable or not.
