### PR TITLE
Adding bitbucket instructions

### DIFF
--- a/content/docs/guides/deploying-nanoc-sites.md
+++ b/content/docs/guides/deploying-nanoc-sites.md
@@ -76,29 +76,28 @@ Every new user need to set up this branch manually.
 
 Now you have an orphaned branch dedicated to GitHub Pages publishing. This branch now dwells in the output folder of your nanoc repository.
 
-With BitBucket.org
------------------
+###With Bitbucket
 
-The publishing of a website based on a git repo is nicely [described in BitBucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
+The publishing of a website based on a git repo is nicely [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
 
-### Setup
-This approach assumes you want a separate git repo on bitbucket.org for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build environment but instead go up a folder level into a different folder.  This saves you from creating a git repo within another git repo.  An example setup on a Mac would look like the following:
+This approach assumes you want a separate Git repo on Bitbucket for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build folder but instead go up a folder level into a different folder.  This saves you from creating a Git repo within another Git repo.  An example setup on a Mac would look like the following:
 
-```
-/Users/me/git/mynanoc_build_env
-/Users/me/git/mybitbucketwebsiterepo
-```
+<span class="filename">/Users/me/git/mynanoc_build_folder</span>
 
-In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
+<span class="filename">/Users/me/git/mybitbucketwebsiterepo</span>
 
-First change the `nanoc.yaml` `output_dir` setting to `../mybitbucketwebsiterepo`
-``` ruby
+
+In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created Bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
+
+First change the `nanoc.yaml` `output_dir` setting to <span class="filename">../mybitbucketwebsiterepo</span>
+
+```yaml
 output_dir: ../mybitbucketwebsiterepo
 ```
 
 Now continue on to the publishing section below and the generated content will go to `../mybitbucketwebsiterepo` instead of the default of `output`.
 
-Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto BitBucket.org.
+Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto Bitbucket.
 
 ```
 git add .


### PR DESCRIPTION
They instructions would also work for GitHub pages I believe, and I also believe they are simpler (at least it was for me).
