### PR TITLE
Document `content_dir` and `layouts_dir`

### DIFF
--- a/content/docs/reference/config.md
+++ b/content/docs/reference/config.md
@@ -132,6 +132,6 @@ This only affects the filesystem data source.
 The path to the directory where the layouts are stored.
 
 	#!yaml
-	layout_dir: layouts
+	layouts_dir: layouts
 
 This only affects the filesystem data source.


### PR DESCRIPTION
This is a potential fix for nanoc/nanoc#488.

(I’m not entirely happy about the structure of the _config.md_ file. I think it should list default values explicitly, and have an example for every case. It also makes sense to have a separate section only for the _filesystem_ data source, I think.)

CC @jm3 @gpakosz 
