### PR TITLE
Add Bitbucket instructions

### DIFF
--- a/content/docs/guides/deploying-nanoc-sites.md
+++ b/content/docs/guides/deploying-nanoc-sites.md
@@ -76,6 +76,37 @@ Every new user need to set up this branch manually.
 
 Now you have an orphaned branch dedicated to GitHub Pages publishing. This branch now dwells in the output folder of your nanoc repository.
 
+With BitBucket.org
+-----------------
+
+The publishing of a website based on a git repo is nicely [described in BitBucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
+
+### Setup
+This approach assumes you want a separate git repo on bitbucket.org for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build environment but instead go up a folder level into a different folder.  This saves you from creating a git repo within another git repo.  An example setup on a Mac would look like the following:
+
+```
+/Users/me/git/mynanoc_build_env
+/Users/me/git/mybitbucketwebsiterepo
+```
+
+In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
+
+First change the `nanoc.yaml` `output_dir` setting to `../mybitbucketwebsiterepo`
+``` ruby
+output_dir: ../mybitbucketwebsiterepo
+```
+
+Now continue on to the publishing section below and the generated content will go to `../mybitbucketwebsiterepo` instead of the default of `output`.
+
+Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto BitBucket.org.
+
+```
+git add .
+git commit -m 'Changed something'
+git push
+```
+
+
 ### Publish
 
 To publish your nanoc site you start with running nanoc as normal:

--- a/content/docs/guides/deploying-nanoc-sites.md
+++ b/content/docs/guides/deploying-nanoc-sites.md
@@ -76,29 +76,28 @@ Every new user need to set up this branch manually.
 
 Now you have an orphaned branch dedicated to GitHub Pages publishing. This branch now dwells in the output folder of your nanoc repository.
 
-With BitBucket.org
------------------
+###With Bitbucket
 
-The publishing of a website based on a git repo is nicely [described in BitBucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
+The publishing of a website based on a git repo is nicely [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
 
-### Setup
-This approach assumes you want a separate git repo on bitbucket.org for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build environment but instead go up a folder level into a different folder.  This saves you from creating a git repo within another git repo.  An example setup on a Mac would look like the following:
+This approach assumes you want a separate Git repo on Bitbucket for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build folder but instead go up a folder level into a different folder.  This saves you from creating a Git repo within another Git repo.  An example setup on a Mac would look like the following:
 
-```
-/Users/me/git/mynanoc_build_env
-/Users/me/git/mybitbucketwebsiterepo
-```
+<span class="filename">/Users/me/git/mynanoc_build_folder</span>
 
-In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
+<span class="filename">/Users/me/git/mybitbucketwebsiterepo</span>
 
-First change the `nanoc.yaml` `output_dir` setting to `../mybitbucketwebsiterepo`
-``` ruby
+
+In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created Bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
+
+First change the `nanoc.yaml` `output_dir` setting to <span class="filename">../mybitbucketwebsiterepo</span>
+
+```yaml
 output_dir: ../mybitbucketwebsiterepo
 ```
 
 Now continue on to the publishing section below and the generated content will go to `../mybitbucketwebsiterepo` instead of the default of `output`.
 
-Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto BitBucket.org.
+Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto Bitbucket.
 
 ```
 git add .

--- a/content/docs/guides/deploying-nanoc-sites.md
+++ b/content/docs/guides/deploying-nanoc-sites.md
@@ -12,7 +12,7 @@ With rsync
 
 If your web host supports rsync, then deploying a site can be fully automated, and the transfer itself can be quite fast, too. rsync is unfortunately a bit cumbersome, providing a great deal of options (check <kbd>man rsync</kbd> in case of doubt), but fortunately nanoc provides a “deploy” command that can make this quite a bit easier: a simple <kbd>nanoc deploy</kbd> will deploy your site.
 
-To use the deploy command, open the `nanoc.yaml` (on older sites: `config.yaml`) file and add a `deploy` hash. Inside, add a hash with a key that describes the destination (for example, `public` or `staging`). Inside this hash, set `dst` to the destination, in the format used by rsync and scp, to where the files should be uploaded, and set `kind` to `rsync`. Here’s what it will look like:
+To use the deploy command, open the <span class="filename">nanoc.yaml</span> (on older sites: <span class="filename">config.yaml</span>) file and add a `deploy` hash. Inside, add a hash with a key that describes the destination (for example, `public` or `staging`). Inside this hash, set `dst` to the destination, in the format used by rsync and scp, to where the files should be uploaded, and set `kind` to `rsync`. Here’s what it will look like:
 
 	#!yaml
 	deploy:
@@ -41,88 +41,59 @@ nanoc will, by default, only update files that have changes, and not remove any 
 
 CAUTION: This will remove all files and directories that do not correspond to nanoc items in the destination. Make sure that the destination does not contain anything that you still need.
 
-With GitHub Pages
------------------
+With GitHub Pages or Bitbucket
+------------------------------
 
-The GitHub Pages deploy process is nicely [described in Github's help pages](https://help.github.com/articles/creating-project-pages-manually).
+[GitHub](https://github.com/) and [Bitbucket](bitbucket.org) are two repository hosting services that support publishing web sites. This section explains how to use their functionality for publishing a website in combination with nanoc.
 
-### Setup
+### GitHub Pages setup
 
-Create a orphaned branch dedicated to GitHub Pages:
+The publishing of a website based on a Git repo to GitHub Pages is [described in Github's help pages](https://help.github.com/articles/creating-project-pages-manually).
 
-<pre><span class="prompt">%</span> <kbd>rm -rf output</kbd>
-<span class="prompt">%</span> <kbd>git branch --orphan gh-pages</kbd></pre>
-
-Clone the current repo into the output directory and <kbd>git checkout</kbd> the new branch:
+Clone the current repo into the <span class="filename">output/</span> directory, create an orphaned branch dedicated to GitHub Pages named `gh-pages`, and check out the new branch:
 
 <pre><span class="prompt">%</span> <kbd>git clone . output</kbd>
 <span class="prompt">%</span> <kbd>cd output</kbd>
-<span class="prompt">%</span> <kbd>git checkout gh-pages</kbd></pre>
-
-Nuke the current content:
-
-<pre><span class="prompt">%</span> <kbd>rm -rf *</kbd>
-<span class="prompt">%</span> <kbd>git add .</kbd>
-<span class="prompt">%</span> <kbd>git commit -am 'Nuke the output directory and gh-pages branch'</kbd></pre>
+<span class="prompt">output@master%</span> <kbd>git branch --orphan gh-pages</kbd>
+<span class="prompt">output@master%</span> <kbd>git checkout gh-pages</kbd>
+<span class="prompt">output@gh-pages%</span> <kbd>cd ..</kbd></pre>
 
 Change the remote for this repo, replacing <var>repo-url</var> with the URL to the repository:
 
-<pre><span class="prompt">%</span> <kbd>git remote rm origin</kbd>
-<span class="prompt">%</span> <kbd>git remote add origin</kbd> <var>repo-url</var></pre>
+<pre><span class="prompt">output@gh-pages%</span> <kbd>git remote rm origin</kbd>
+<span class="prompt">output@gh-pages%</span> <kbd>git remote add origin</kbd> <var>repo-url</var></pre>
 
-Add the `output` folder to your `.gitignore`. (Adding it to the repo does not help.)
+Add the <span class="filename">output/</span> directory to your <span class="filename">.gitignore</span>. Make sure that the base repository doesn’t contain <span class="filename">output/</span>.
 
-Every new user need to set up this branch manually.
+### Bitbucket setup
 
-Now you have an orphaned branch dedicated to GitHub Pages publishing. This branch now dwells in the output folder of your nanoc repository.
+The publishing of a website based on a Git repo to Bitbucket is [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
 
-###With Bitbucket
+Bitbucket supports publishing a website at <var>username</var>.bitbucket.org, where <var>username</var> is your Bitbucket account name. The contents of the web site will be read from a repository named <var>username</var>.bitbucket.org.
 
-The publishing of a website based on a git repo is nicely [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
+First of all, create the Bitbucket repository <var>username</var>.bitbucket.org. For example, _ddfreyne.bitbucket.org_.
 
-This approach assumes you want a separate Git repo on Bitbucket for both your nanoc build environment and for the generated website content.  The concept is to not have the generated content be placed in a child folder of the build folder but instead go up a folder level into a different folder.  This saves you from creating a Git repo within another Git repo.  An example setup on a Mac would look like the following:
+Create a new Git repository inside the <span class="filename">output/</span> directory, replacing <var>repo-url</var> with the URL to the repository (e.g. `git@bitbucket.org:ddfreyne/ddfreyne.bitbucket.org.git`):
 
-<span class="filename">/Users/me/git/mynanoc_build_folder</span>
+<pre><span class="prompt">%</span> <kbd>git init output/</kbd>
+<span class="prompt">%</span> <kbd>cd output/</kbd>
+<span class="prompt">output%</span> <kbd>git remote add origin</kbd> <var>repo-url</var></pre>
 
-<span class="filename">/Users/me/git/mybitbucketwebsiterepo</span>
-
-
-In the above example `mynanoc_build_folder` is where files your nanoc folders and files reside (i.e. `Rules`, `nanoc.yaml`, `content/`, `layouts/`, `lib/`, etc).  The `mybitbucketwebsiterepo` folder is a separately created Bitbucket repo that is waiting to be occupied with the generated content from `mynanoc_build_folder`.
-
-First change the `nanoc.yaml` `output_dir` setting to <span class="filename">../mybitbucketwebsiterepo</span>
-
-```yaml
-output_dir: ../mybitbucketwebsiterepo
-```
-
-Now continue on to the publishing section below and the generated content will go to `../mybitbucketwebsiterepo` instead of the default of `output`.
-
-Once you've generate the new site then `cd` into `../mybitbucketwebsiterepo` and do the normal flow of placing changes back onto Bitbucket.
-
-```
-git add .
-git commit -m 'Changed something'
-git push
-```
-
+Add the <span class="filename">output/</span> directory to your <span class="filename">.gitignore</span>. Make sure that the base repository doesn’t contain <span class="filename">output/</span>.
 
 ### Publish
 
-To publish your nanoc site you start with running nanoc as normal:
+To publish your nanoc site, first compile site:
 
 <pre><span class="prompt">%</span> <kbd>nanoc</kbd></pre>
 
-Jump into output, commit the result and push the publishing branch:
+Enter the <span class="filename">output/</span> directory, add and commit everything, and push:
 
 <pre><span class="prompt">%</span> <kbd>cd output</kbd>
-<span class="prompt">%</span> <kbd>git add .</kbd>
-<span class="prompt">%</span> <kbd>git commit -am 'Content created'</kbd>
-<span class="prompt">%</span> <kbd>git push origin gh-pages</kbd></pre>
+<span class="prompt">output%</span> <kbd>git add .</kbd>
+<span class="prompt">output%</span> <kbd>git commit -m 'Update compiled output'</kbd>
+<span class="prompt">output%</span> <kbd>git push</kbd></pre>
 
-Wait a couple of minutes and your content will appear at <code>http://<var>your-GitHub-username</var>.github.com/<var>your-GitHub-repository-name</var></code>.
+After a few seconds, the updated site will appear at <span class="uri">http://<var>username</var>.github.io/<var>repo-name</var></span> for GitHub, or <span class="uri">http://<var>username</var>.bitbucket.org</span> for Bitbucket.
 
-The above five lines can be put into a shell script for easy publishing. (Or you could create a deployer for this setup. Any takers?)
-
-With this approach, nanoc is happy, because the output folder is where it is supposed to be, and GitHub Pages is happy as well, because there is a nice and tidy branch called `gh-pages` with static publishable content.
-
-A weird side effect is that the `gh-pages` branch in the output directory is likely to be out of sync with the gh-pages branch in your base repo. You can either remove the branch from the base repo, or just make sure to `pull` after a succesful publish.
+For GitHub, we recommend removing the _gh-pages_ branch from the base repository, since it is quite likely to be out of sync with the _gh-pages_ branch in the repository in the <span class="filename">output/</span> directory.


### PR DESCRIPTION
This adds instructions on how to publish a nanoc web site with Bitbucket, and also simplifies the existing GitHub Pages guidelines.

This replaces #67.