### PR TITLE
Specify minimum Ruby version (1.9.3)

### DIFF
--- a/content/install.md
+++ b/content/install.md
@@ -13,7 +13,7 @@ For detailed instructions, read on!
 
 ## Installing Ruby
 
-nanoc requires [Ruby](http://ruby-lang.org/) in order to run. nanoc supports the official Ruby interpreter from version 1.8.6 up, as well as JRuby.
+nanoc requires [Ruby](http://ruby-lang.org/) in order to run. nanoc supports the official Ruby interpreter from version 1.9.3 up, as well as JRuby.
 
 Ruby may already be installed on your system. To check, open a terminal window and type <kbd>ruby --version</kbd>. If you get “command not found”, Ruby is not yet installed. Otherwise, you will see which version of Ruby you have:
 


### PR DESCRIPTION
Realistically, nanoc 3.6.9+ only supported Ruby 1.9.3+. This PR makes the dependency on 1.9.3+ explicit.

I don’t think we need to mention the last version compatible with 1.8.x here. I’d only mention the last 1.8.x-compatible version in the e-mail that announces the end of 1.8.x support.

See also:

* nanoc/nanoc#517: PR for removing 1.8.x support in nanoc
* nanoc/nanoc#513: Discussion around removing 1.8.x support

CC @nanoc/contributors @sudrien