### PR TITLE
Add “Try nanoc 4 beta!” button

### DIFF
--- a/content/assets/style/_color.scss
+++ b/content/assets/style/_color.scss
@@ -130,8 +130,10 @@ body header {
     .header-content {
         background: $nav-bg-color;
 
-        nav li {
-            border-color: $nav-spacing-color;
+        nav {
+            li {
+                border-color: $nav-spacing-color;
+            }
 
             a:link, a:visited {
                 color: $light-fg-color;
@@ -140,10 +142,20 @@ body header {
             a:hover {
                 color: $emph-light-fg-color;
             }
-        }
 
-        nav li.active > span {
-            color: $emph-light-fg-color;
+            li.active > span {
+                color: $emph-light-fg-color;
+            }
+
+            .try-nanoc-4-beta {
+                a {
+                    background: #000;
+                }
+
+                a:hover {
+                    background: $link-color-a;
+                }
+            }
         }
     }
 }

--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -251,6 +251,24 @@ body header {
                     background-size: 32px 32px;
                 }
             }
+
+            @media (max-width: 719px) {
+                .try-nanoc-4-beta {
+                    display: none;
+                }
+            }
+
+            .try-nanoc-4-beta {
+                float: right;
+                font-size: 13px;
+
+                a {
+                    display: inline-block;
+                    height: 100%;
+                    padding: 10px 18px 11px 18px;
+                    border-radius: 0;
+                }
+            }
         }
     }
 }

--- a/content/assets/style/screen.scss
+++ b/content/assets/style/screen.scss
@@ -1,5 +1,5 @@
 ---
-version:    40
+version:    41
 is_hidden:  true
 is_dynamic: true
 ---

--- a/content/docs/nanoc-4-upgrade-guide.md
+++ b/content/docs/nanoc-4-upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
-title: "nanoc 4.0 upgrade guide"
+title: "nanoc 4 upgrade guide"
 for_nanoc_4: true
 ---
 
-The [nanoc 4 upgrade guide](http://v4.nanoc.ws/docs/nanoc-4-upgrade-guide/), along with up-to-date information about nanoc 4, now lives on the [nanoc 4 pre-release site](http://v4.nanoc.ws/).
+The nanoc 4 upgrade guide, along with up-to-date information about nanoc 4, has moved to the [nanoc 4 pre-release site](http://v4.nanoc.ws/docs/nanoc-4-upgrade-guide/).

--- a/layouts/default.html.erb
+++ b/layouts/default.html.erb
@@ -20,6 +20,7 @@
                         <%= nav_link @items['/community/'] %>
                         <%= nav_link @items['/contributing/'] %>
                     </ol>
+                    <span class="try-nanoc-4-beta"><a href="http://v4.nanoc.ws/docs/nanoc-4-upgrade-guide/">Try nanoc 4 beta!</a></span>
                 </nav>
                 <%#
                 <div class="search">


### PR DESCRIPTION
This adds a _Try nanoc 4 beta!_ button to the top right hand side of the navigation. It is pretty subtle in its normal state, but lights up on hover.

The button is hidden on the mobile stylesheet. The lack of screen space on mobile devices made me not want to put the button on there.

Before putting this live, I’d like to finish the nanoc 4 upgrade page, and also add some “marketing copy”—the page is quite dry at the moment, and I doubt it convinces many people to give nanoc 4 a try.

Normal state:

![try-nanoc-4](https://cloud.githubusercontent.com/assets/6269/7783106/b0fc6d86-0135-11e5-94e0-9f2088b95413.png)

Hover:

![try-nanoc-4-hover](https://cloud.githubusercontent.com/assets/6269/7783107/b1002e08-0135-11e5-8816-b09832bcb83a.png)
