### PR TITLE
Freshen up site design

### DIFF
--- a/content/assets/style/_color.scss
+++ b/content/assets/style/_color.scss
@@ -1,27 +1,35 @@
 // Reusable colors
-$emph-color:            rgb(210, 67, 27);
+$emph-color:            saturate(rgb(210, 67, 27), 40%);
+$lighter-emph-color:    tint($emph-color, 30%);
+
+// Intro
+$intro-bg-color:        $lighter-emph-color;
+$intro-fg-color:        #fff;
 
 // background
-$bg-color:              #f1f0eb;
-$semilight-bg-color:    adjust-hue(saturate(shade($bg-color, 15%), 15%), -30%);
+$bg-color:              tint(#f1f0eb, 40%);
+$hero-bg-color:         adjust-hue(saturate(shade($bg-color, 15%), 15%), -30%);
 $top-bg-color:          shade($bg-color, 70%);
 $footer-bg-color:       $top-bg-color;
 $footer-border-color:   shade($bg-color, 50%);
 $nav-bg-color:          shade($top-bg-color, 60%);
 $search-bg-color:       shade($top-bg-color, 30%);
 $nav-spacing-color:     $top-bg-color;
-$explanation-bg-color:  shade($emph-color, 10%);
+$explanation-bg-color:  $lighter-emph-color;
 $ticker-bg-color:       shade($bg-color, 70%);
-$chooser-unit-bg-color: $emph-color;
+$chooser-unit-bg-color: $lighter-emph-color;
 $tr-odd-color:          shade($bg-color, 5%);
+$sidebar-bg-color:      rgba(255, 255, 255, 0.8);
 
 // foreground
 $tagline-color:         tint($top-bg-color, 40%);
+// $active-bar-color:      rgb(210, 67, 27);
+$active-bar-color:      $emph-color;
 $dark-fg-color:         $search-bg-color;
 $light-fg-color:        #ddd6d4;
 $emph-light-fg-color:   #fff;
 $chooser-unit-fg-color: #fff;
-$link-color-a:          #2366ad;
+$link-color-a:          saturate(#2366ad, 20%);
 $link-color-b:          #fff;
 $footer-link-color-a:   $light-fg-color;
 $footer-link-color-b:   shade($footer-bg-color, 40%);
@@ -33,6 +41,9 @@ $admon-color-tip:       adjust-hue($link-color-a, 240deg);
 $admon-color-note:      $link-color-a;
 $admon-color-caution:   $emph-color;
 $admon-color-done:      adjust-hue($link-color-a, -120%);
+
+$border-color:          shade($bg-color, 5%);
+$emph-bg-color:         tint($bg-color, 60%);
 
 
 
@@ -93,16 +104,15 @@ figure {
 }
 
 pre {
-    border: 1px solid shade($bg-color, 20%);
-    background: tint($bg-color, 50%);
-}
-
-pre:after {
-    background: shade($bg-color, 20%);
+    border-radius: 4px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    background: $emph-bg-color;
 }
 
 div.admonition-wrapper {
-    background: shade($bg-color, 5%);
+    box-shadow: inset 0 0 0 1px $border-color;
+
+    background: $emph-bg-color;
 }
 
 div.admonition-wrapper:before {
@@ -152,6 +162,23 @@ body header {
                 color: $emph-light-fg-color;
             }
 
+            @media (min-width: 720px) {
+                li.active > span,
+                li.active > a {
+                    border-top: 3px solid $active-bar-color;
+                }
+            }
+
+            @media (max-width: 719px) {
+                li.active:nth-child(even) {
+                    border-left: 3px solid $active-bar-color;
+                }
+
+                li.active:nth-child(odd) {
+                    border-right: 3px solid $active-bar-color;
+                }
+            }
+
             .for-nanoc-4-beta {
                 span {
                     color: $light-fg-color;
@@ -164,15 +191,15 @@ body header {
 
 body.page {
     .intro {
-        background: $semilight-bg-color;
+        background: $intro-bg-color;
+
+        h1 {
+            color: $intro-fg-color;
+        }
     }
 
-    .details, .open-source-site {
-        background: rgba(255, 255, 255, 0.7);
-    }
-
-    .open-source-site {
-        border-color: #fff;
+    .details {
+        background: $sidebar-bg-color;
     }
 
     tr.odd td {
@@ -187,7 +214,7 @@ body.home {
     }
 
     .hero {
-        background-color: $semilight-bg-color;
+        background-color: $hero-bg-color;
 
         .caption {
             background: shade($bg-color, 5%);

--- a/content/assets/style/_color.scss
+++ b/content/assets/style/_color.scss
@@ -119,20 +119,40 @@ div.admonition-wrapper:before {
     color: #fff;
 }
 
+div.admonition-wrapper.tip {
+    box-shadow: inset 0 0 0 1px $link-color-a;
+}
+
 div.admonition-wrapper.tip:before {
     background-color: $link-color-a;
+}
+
+div.admonition-wrapper.note {
+    box-shadow: inset 0 0 0 1px $link-color-a;
 }
 
 div.admonition-wrapper.note:before {
     background-color: $link-color-a;
 }
 
+div.admonition-wrapper.caution {
+    box-shadow: inset 0 0 0 1px $emph-color;
+}
+
 div.admonition-wrapper.caution:before {
     background-color: $emph-color;
 }
 
+div.admonition-wrapper.done {
+    box-shadow: inset 0 0 0 1px $admon-color-done;
+}
+
 div.admonition-wrapper.done:before {
     background-color: $admon-color-done;
+}
+
+div.admonition-wrapper.todo {
+    box-shadow: inset 0 0 0 1px desaturate($emph-color, 75%);
 }
 
 div.admonition-wrapper.todo:before {

--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -12,9 +12,9 @@ $grid-padding:  0;
 // GENERAL STYLING
 
 body {
-    font-family: "Open Sans";
+    font-family: "Source Sans Pro";
     font-weight: normal;
-    font-size: 14px;
+    font-size: 15px;
     line-height: 20px;
 }
 
@@ -51,6 +51,8 @@ pre {
 
 div.admonition-wrapper {
     margin: 0 0 20px 0;
+
+    border-radius: 4px;
 }
 
 div.admonition-wrapper:before {
@@ -60,6 +62,8 @@ div.admonition-wrapper:before {
     width: 28px;
 
     padding: 10px;
+
+    border-radius: 4px 0 0 4px;
 }
 
 div.admonition-wrapper .admonition {
@@ -173,8 +177,6 @@ body header {
 
                     li.active > span,
                     li.active > a {
-                        // TODO move this to _colors.scss
-                        border-top: 3px solid rgb(210, 67, 27);
                         padding-top: 7px;
                         border-radius: 0;
                     }
@@ -203,14 +205,10 @@ body header {
                     }
 
                     li.active:nth-child(even) {
-                        // TODO move this to _colors.scss
-                        border-left: 3px solid rgb(210, 67, 27);
                         padding-right: 3px;
                     }
 
                     li.active:nth-child(odd) {
-                        // TODO move this to _colors.scss
-                        border-right: 3px solid rgb(210, 67, 27);
                         padding-left: 3px;
                     }
                 }
@@ -495,7 +493,7 @@ body.page .content {
                 margin: 40px 0 0 0;
             }
 
-            .details, .open-source-site {
+            .details {
                 padding: 20px;
                 margin-bottom: 20px;
             }
@@ -536,16 +534,6 @@ body.page .content {
 
                 ul li {
                     list-style-type: none;
-                }
-            }
-
-            .open-source-site {
-                border-width: 6px;
-                border-style: solid;
-
-                p {
-                    font-size: 12px;
-                    padding: 0;
                 }
             }
         }
@@ -803,7 +791,7 @@ body.home .support {
 
 footer {
     p {
-        font-size: 12px;
+        font-size: 13px;
     }
 
     a {

--- a/content/assets/style/_tags.scss
+++ b/content/assets/style/_tags.scss
@@ -43,6 +43,7 @@ pre.legacy:before {
 
     background: #999;
     color: #fff;
+    border-top-right-radius: 4px;
 }
 
 pre.new:before {
@@ -50,6 +51,7 @@ pre.new:before {
 
     background: $link-color-a;
     color: #fff;
+    border-top-right-radius: 4px;
 }
 
 pre.legacy:before,

--- a/layouts/default.html.erb
+++ b/layouts/default.html.erb
@@ -5,7 +5,7 @@
         <title><%= @item[:full_title] || 'nanoc &raquo; ' + (content_for(@item, :title) || @item[:title]) %></title>
         <link href="<%= @items['/assets/style/screen.*'].path %>" media="screen" rel="stylesheet">
         <link href="<%= @items['/assets/style/print.*'].path %>"  media="print" rel="stylesheet">
-        <link href='//fonts.googleapis.com/css?family=Open+Sans:400,600,700' rel='stylesheet' type='text/css'>
+        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic' rel='stylesheet' type='text/css'>
         <meta name="viewport" content="width=device-width">
         <% if @item[:redirect_to] %>
             <meta http-equiv="refresh" content="0;URL='<%= @item[:redirect_to] %>'">
@@ -53,9 +53,6 @@
                             {{TOC}}
                         </div>
                     <% end %>
-                    <div class="open-source-site">
-                        <p>This site is <a href="http://github.com/nanoc/nanoc.ws">hosted on GitHub</a>. If you want to help out, do report issues and submit pull requests!</p>
-                    </div>
                 </div>
                 <div class="article-content">
                     <%= yield %>


### PR DESCRIPTION
A fresh start (nanoc 4) requires an updated site design.

* Colors
  * The theme is generally brighter.
  * The primary emphasis color is now orange rather than a (dark, unsaturated) red.
* Fonts
  * Open Sans is out, Source Sans Pro is in.
* Contents
  * The “this site is open-source” box below the sidebar is gone. It distracts from the content.

One big task that is still ahead is the visual refresh of the homepage. There are few things I’d like to highlight there:

* Sites using nanoc (already the case)
* Testimonials (don’t have any yet, and not sure how to collect them)
* Features (just a list of ideas):
  * Rules file (along with identifiers with extensions + glob syntax)
  * Static output
  * Comes with a bunch of useful plugins
  * Customisability (own filters, own data sources)
  * _check_ command

Anyway, here’s a screenshot of the Installation page (right = new):

![screen shot 2015-06-15 at 21 28 47](https://cloud.githubusercontent.com/assets/6269/8168769/8ed32eb6-13a5-11e5-825f-95804ef8708a.png)
