### PR TITLE
Reword double-star explanation

### DIFF
--- a/content/doc/identifiers-and-patterns.md
+++ b/content/doc/identifiers-and-patterns.md
@@ -76,8 +76,8 @@ For glob patterns, nanoc supports the following wildcards:
 `*`
 : Matches any file or directory name. Does not cross directory boundaries. For example, `/projects/*.md` matches `/projects/nanoc.md`, but not `/projects/cri.adoc` nor `/projects/nanoc/about.md`.
 
-`**`
-: Matches any file or directory name, and crosses directory boundaries. For example, `/projects/**/*.md` matches both `/projects/nanoc.md` and `/projects/nanoc/history.md`.
+`**/`
+: Matches zero or more levels of nested directories. For example, `/projects/**/*.md` matches both `/projects/nanoc.md` and `/projects/nanoc/history.md`.
 
 `?`
 : Matches a single character.


### PR DESCRIPTION
The original explanation was not as clear as it could be. This new explanation is more clear.

See nanoc/nanoc#639.

CC @remko