### PR TITLE
Update API documentation

### DIFF
--- a/content/doc/identifiers-and-patterns.md
+++ b/content/doc/identifiers-and-patterns.md
@@ -17,10 +17,10 @@ legacy
 
 The following methods are useful for full identifiers:
 
-`identifier.with_ext(string)` &rarr; String
+`identifier.with_ext(string)` &rarr; `String`
 : identifier with the extension replaced with the given string
 
-`identifier.without_ext` &rarr; String
+`identifier.without_ext` &rarr; `String`
 : identifier with the extension removed
 
 Here are some examples:
@@ -37,10 +37,10 @@ Here are some examples:
 The following methods are useful for legacy identifiers:
 
 {: .legacy}
-`identifier.chop` &rarr; String
+`identifier.chop` &rarr; `String`
 : identifier with the last character removed
 
-`identifier + string` &rarr; String
+`identifier + string` &rarr; `String`
 : identifier with the given string appended
 
 Here are some examples:

--- a/content/doc/reference/variables.md
+++ b/content/doc/reference/variables.md
@@ -34,20 +34,42 @@ There are three contexts in which variables are exposed: in the `preprocess` blo
 
 The `@config` variable contains the site configuration, read from _nanoc.yaml_.
 
-`@config[:someattribute]`
-: The attribute for the given key.
+`@config[:some_key]` &rarr; _object_
+: The attribute for the given key, or `nil` if the key is not found.
+
+`@config.fetch(:some_key, fallback)` &rarr; _object_
+: The attribute for the given key, or `fallback` if the key is not found.
+
+`@config.fetch(:some_key) { |key| … }` &rarr; _object_
+: The attribute for the given key, or the value of the block if the key is not found.
+
+`@config.key?(:some_key)` &rarr; `true` / `false`
+: Whether or not an attribute with the given key exists.
+
+The following methods are available during preprocessing:
+
+`@config[:some_key] = some_value` &rarr; _nothing_
+: Assigns the given value to the attribute with the given key.
 
 ## `@items` and `@layouts`
 
 The `@items` variable contains all items in the site. Similarly, `@layouts` contains all layouts.
 
-`@items[arg]`
-`@layouts[arg]`
-: Finds a single item or layout using the given argument. See below for details.
+`@items[arg]` &rarr; _object_
+`@layouts[arg]` &rarr; _object_
+: The single item or layout that matches given argument, or nil if nothing is found.
 
-`@items.find_all(arg)`
-`@layouts.find_all(arg)`
-: Finds all items or layouts using the given argument. See below for details.
+`@items.each { |item| … }` &rarr; _nothing_
+`@layouts.each { |item| … }` &rarr; _nothing_
+: Yields every item or layout.
+
+`@items.find_all(arg)` &rarr; _collection of items_
+`@layouts.find_all(arg)` &rarr; _collection of layouts_
+: All items or layouts that match given argument.
+
+`@items.size` &rarr; `Integer`
+`@layouts.size` &rarr; `Integer`
+: The number of items.
 
 Both `@items` and `@layouts` include Ruby’s `Enumerable`, which means useful methods such as `#map` and `#select` are available.
 
@@ -68,58 +90,131 @@ Additionally, you can pass a regular expression to the `#[]` method, which will 
 
 The `#find_all` method is similar to `#[]`, but returns a collection of items or layouts, rather than a single result.
 
+The following methods are available during preprocessing:
+
+`@items.delete_if { |item| … }` &rarr; _nothing_
+`@layouts.delete_if { |layout| … }` &rarr; _nothing_
+: Removes any item or layout for which the given block returns true.
+
+`@items.create(content, attributes, identifier)` &rarr; _nothing_
+`@items.create(content, attributes, identifier, binary: true)` &rarr; _nothing_
+`@layouts.create(content, attributes, identifier)` &rarr; _nothing_
+: Creates an item with the given content, attributes, and identifier. For items, if the `:binary` parameter is `true`, the content will be considered binary.
+
 ## `@item`
 
 The `@item` variable contains the item that is currently being processed. This variable is available within compilation and routing rules, as well as while filtering and laying out an item.
 
-`@item.identifier`
-: The identifier, e.g. `/about.md`, or `/about/` (with legacy identifier format).
-
-`@item[:someattribute]`
+`@item[:someattribute]` &rarr; _object_
 : The attribute for the given key.
 
-`@item.path`
-: Shorthand for `@item.rep_named(:default).path`.
+`@item.binary?` &rarr; `true` / `false`
+: Whether or not the source content of this item is binary.
 
-`@item.compiled_content`
-: Shorthand for `@item.rep_named(:default).compiled_content`. Pass `:rep` to
-  get the compiled content for a non-default rep, and `:snapshot` to get the
-  compiled content for a non-default snapshot.
+`@item.compiled_content` &rarr; `String`
+`@item.compiled_content(rep: :foo)` &rarr; `String`
+`@item.compiled_content(snapshot: :bar)` &rarr; `String`
+: The compiled content. The `:rep` option specifies the item representation (`:rep` by default), while `:snapshot` specifies the snapshot (`:last` by default).
+
+`@item.fetch(:some_key, fallback)` &rarr; _object_
+: The attribute for the given key, or `fallback` if the key is not found.
+
+`@item.fetch(:some_key) { |key| … }` &rarr; _object_
+: The attribute for the given key, or the value of the block if the key is not found.
+
+`@item.identifier` &rarr; _identifier_
+: The identifier, e.g. `/about.md`, or `/about/` (with legacy identifier format).
+
+`@item.key?(some_key)` &rarr; `true` / `false`
+: Whether or not an attribute with the given key exists.
+
+`@item.path` &rarr; `String`
+`@item.path(rep: :foo)` &rarr; `String`
+`@item.path(snapshot: :bar)` &rarr; `String`
+: The path to the compiled item. The `:rep` option specifies the item representation (`:rep` by default), while `:snapshot` specifies the snapshot (`:last` by default).
+
+`@item.reps` &rarr; _collection of reps_
+: The collection of representations for this item.
 
 For items that use the legacy identifier format (e.g. `/page/` rather than `/page.md`), the following methods are available:
 
 {: .legacy}
-`@item.parent`
+`@item.parent` &rarr; _item_ / `nil`
 : The parent of this item, i.e. the item that corresponds with this item’s
   identifier with the last component removed. For example, the parent of the
   item with identifier `/foo/bar/` is the item with identifier `/foo/`.
 
-`@item.children`
+`@item.children` &rarr; _collection of items_
 : The items for which this item is the parent.
+
+The following methods are available during preprocessing:
+
+`@item[:some_key] = some_value` &rarr; _nothing_
+: Assigns the given value to the attribute with the given key.
+
+`@item.update_attributes(some_hash)` &rarr; _nothing_
+: Updates the attributes based on the given hash.
+
+The item reps collection (`@item.reps`) has the following methods:
+
+`@item.reps[:name]` &rarr; _item rep_ / `nil`
+: The item representation with the given name, or `nil` if the requested item rep does not exists.
+
+`@item.reps.each { |rep| … }` &rarr; _nothing_
+: Yields every item representation.
+
+`@item.reps.fetch(:name)` &rarr; _item rep_
+: The item representation with the given name. Raises if the requested item rep does not exist.
+
+`@item.reps.size` &rarr; `Integer`
+: The number of item representations.
+
+Item representation collections include Ruby’s `Enumerable`, which means useful methods such as `#map` and `#select` are available.
 
 ## `@layout`
 
 The `@layout` variable contains the layout that is currently being used. This variable is only available while laying out an item.
 
-`@layout.identifier`
-: The identifier, e.g. `/page.erb`, or `/page/` (with legacy identifier format).
-
-`@layout[:someattribute]`
+`@layout[:someattribute]` &rarr; _object_
 : The attribute for the given key.
+
+`@layout.fetch(:some_key, fallback)` &rarr; _object_
+: The attribute for the given key, or `fallback` if the key is not found.
+
+`@layout.fetch(:some_key) { |key| … }` &rarr; _object_
+: The attribute for the given key, or the value of the block if the key is not found.
+
+`@layout.identifier` &rarr; _identifier_
+: The identifier, e.g. `/about.md`, or `/about/` (with legacy identifier format).
+
+`@layout.key?(some_key)` &rarr; `true` / `false`
+: Whether or not an attribute with the given key exists.
+
+The following methods are available during preprocessing:
+
+`@layout[:some_key] = some_value` &rarr; _nothing_
+: Assigns the given value to the attribute with the given key.
+
+`@layout.update_attributes(some_hash)` &rarr; _nothing_
+: Updates the attributes based on the given hash.
 
 ## `@item_rep` or `@rep`
 
 The `@item_rep` variable contains the item representation that is currently being processed. It is also available as `@rep`. This variable is available wwhile filtering and laying out an item.
 
-`@item_rep.item`
+`@item_rep.binary?` &rarr; `true` / `false`
+: Whether or not the content of this item representation is binary.
+
+`@item_rep.item` &rarr; _item_
 : The item for the item rep.
 
-`@item_rep.path`
-: The path to the item rep, without `index.html`.
-
-`@item_rep.name`
+`@item_rep.name` &rarr; `Symbol`
 : The name of the item rep, e.g. `:default`.
 
-`@item_rep.compiled_content`
-: Gets the compiled content at the `:default` snapshot. Pass `:snapshot` to get
-  the compiled content for a non-default snapshot.
+`@item_rep.path` &rarr; `String`
+`@item_rep.path(snapshot: :foo)` &rarr; `String`
+: The path to the compiled item representation. The `:snapshot` specifies the snapshot (`:last` by default).
+
+`@item_rep.compiled_content` &rarr; `String`
+`@item_rep.compiled_content(snapshot: :bar)` &rarr; `String`
+: The compiled content. The `:snapshot` specifies the snapshot (`:last` by default).


### PR DESCRIPTION
* Added the documentation for several methods on several objects.
* Added return types.

I initially had a tag for methods available only during pre-processing, but this turned out not to work so well (both visually and in terms of markup).

The documentation for item representations lives under the documentation for `@item`, which is not ideal.

It might be a good idea to convert the _Variables_ page into an _API_ reference page, and document all methods of all public types there (including identifiers and item representations).