### PR TITLE
Make dts black+bold rather than orange

### DIFF
--- a/content/assets/style/_base.scss
+++ b/content/assets/style/_base.scss
@@ -55,6 +55,7 @@ h1, h2, h3, h4, h5, h6 {
 
 dt {
     color: $dt-color;
+    font-weight: bold;
 }
 
 article {

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -81,7 +81,7 @@ $sidebar-bg-color:            rgba(255, 255, 255, 0.8);
 
 // Typography
 $header-color:                $color-orange;
-$dt-color:                    $color-orange;
+$dt-color:                    $color-black;
 
 @mixin dark-background-links {
     a:link, a:visited {


### PR DESCRIPTION
Orange is reserved for headers. It doesn’t make sense to have definition list terms orange too.

Sample (left=old, right=new):

![dts](https://cloud.githubusercontent.com/assets/6269/8267095/88ce9134-1753-11e5-83e5-4437b47982d5.png)
