### PR TITLE
Fix mobile footer links

### DIFF
--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -368,7 +368,7 @@ footer {
 
             ul {
                 li {
-                    display: inline;
+                    display: inline-block;
                 }
 
                 li:before {

--- a/content/assets/style/_layout.scss
+++ b/content/assets/style/_layout.scss
@@ -335,7 +335,7 @@ footer {
     @include dark-background-links;
 
     .links {
-        div, li:before {
+        div, li:after {
             color: $dark-fg-color;
         }
     }
@@ -371,12 +371,12 @@ footer {
                     display: inline-block;
                 }
 
-                li:before {
+                li:after {
                     padding: 0 5px;
                     content: "\00B7";
                 }
 
-                li:first-child:before {
+                li:last-child:after {
                     padding: 0;
                     content: "";
                 }


### PR DESCRIPTION
This fixes an issue with the list of links in the footer overflowing on small screens (e.g. mobile).

**Before:**

![before](https://cloud.githubusercontent.com/assets/6269/8512830/88d76cb0-2355-11e5-984f-c7af012fbb09.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/6269/8512831/88d9dc70-2355-11e5-8ece-8f7b14db279a.png)

Unfortunately, I have no idea why this fixes the issue.

I’m also not sure where the middle dot should go. Probably at the end of the line, rather than at the beginning.