### PR TITLE
Simpler lib

### DIFF
--- a/lib/data_sources/cli.rb
+++ b/lib/data_sources/cli.rb
@@ -1,48 +1,40 @@
-# encoding: utf-8
+Class.new(Nanoc::DataSource) do
+  identifier :cli
 
-module NanocSite
+  def items
+    items = []
 
-  class CLIDataSource < Nanoc::DataSource
+    if Nanoc::CLI.root_command.nil?
+      Nanoc::CLI.setup
+    end
+    root_cmd = Nanoc::CLI.root_command
 
-    identifier :cli
-
-    def items
-      items = []
-
-      if Nanoc::CLI.root_command.nil?
-        Nanoc::CLI.setup
-      end
-      root_cmd = Nanoc::CLI.root_command
-
-      root_cmd.subcommands.select { |c| !c.hidden? }.each do |subcmd|
-        items << cmd_to_item(subcmd)
-      end
-
-      items
+    root_cmd.subcommands.select { |c| !c.hidden? }.each do |subcmd|
+      items << cmd_to_item(subcmd)
     end
 
-    protected
-
-    def cmd_to_item(cmd)
-      slug = cmd.name.downcase.gsub(/[^a-z0-9]+/, '-')
-      opt_defs = cmd.option_definitions.map do |od|
-        od.reject { |k,v| k == :block }
-      end
-
-      new_item(
-        '-',
-        {
-          :type               => 'command',
-          :name               => cmd.name,
-          :summary            => cmd.summary,
-          :description        => cmd.description,
-          :aliases            => cmd.aliases,
-          :option_definitions => opt_defs,
-          :usage              => cmd.usage
-        },
-        Nanoc::Identifier.new("/_#{slug}", style: :full))
-    end
-
+    items
   end
 
+  protected
+
+  def cmd_to_item(cmd)
+    slug = cmd.name.downcase.gsub(/[^a-z0-9]+/, '-')
+    opt_defs = cmd.option_definitions.map do |od|
+      od.reject { |k,v| k == :block }
+    end
+
+    new_item(
+      '-',
+      {
+        :type               => 'command',
+        :name               => cmd.name,
+        :summary            => cmd.summary,
+        :description        => cmd.description,
+        :aliases            => cmd.aliases,
+        :option_definitions => opt_defs,
+        :usage              => cmd.usage
+      },
+      Nanoc::Identifier.new("/_#{slug}", style: :full))
+  end
 end

--- a/lib/data_sources/contributors.rb
+++ b/lib/data_sources/contributors.rb
@@ -1,21 +1,17 @@
-# encoding: utf-8
+Class.new(Nanoc::DataSource) do
+  identifier :contributors
 
-module NanocSite
-  class ContributorsDataSource < Nanoc::DataSource
-    identifier :contributors
+  def items
+    path = Bundler.rubygems.find_name('nanoc').first.full_gem_path
+    raw_content = File.read(File.join(path, 'README.md'))
+    content = raw_content.lines.to_a.last
 
-    def items
-      path = Bundler.rubygems.find_name('nanoc').first.full_gem_path
-      raw_content = File.read(File.join(path, 'README.md'))
-      content = raw_content.lines.to_a.last
+    item = new_item(
+      content,
+      {},
+      Nanoc::Identifier.new('/contributing/_contributors')
+    )
 
-      item = new_item(
-        content,
-        {},
-        Nanoc::Identifier.new('/contributing/_contributors')
-      )
-
-      [item]
-    end
+    [item]
   end
 end

--- a/lib/data_sources/release_notes.rb
+++ b/lib/data_sources/release_notes.rb
@@ -1,32 +1,24 @@
-# encoding: utf-8
+Class.new(Nanoc::DataSource) do
+  identifier :release_notes
 
-module NanocSite
+  def items
+    # content
+    path = Bundler.rubygems.find_name('nanoc').first.full_gem_path
+    raw_content = File.read("#{path}/NEWS.md")
+    content = raw_content.sub(/^#.*$/, '') # remove h1
 
-  class ReleaseNotesDataSource < Nanoc::DataSource
+    # attributes
+    attributes = {
+      title: 'Release Notes',
+      markdown: 'basic',
+      extension: 'md'
+    }
 
-    identifier :release_notes
+    # identifier
+    identifier = Nanoc::Identifier.new('/release-notes', style: :full)
 
-    def items
-      # content
-      path = Bundler.rubygems.find_name('nanoc').first.full_gem_path
-      raw_content = File.read("#{path}/NEWS.md")
-      content = raw_content.sub(/^#.*$/, '') # remove h1
+    item = new_item(content, attributes, identifier)
 
-      # attributes
-      attributes = {
-        title: 'Release Notes',
-        markdown: 'basic',
-        extension: 'md'
-      }
-
-      # identifier
-      identifier = Nanoc::Identifier.new('/release-notes', style: :full)
-
-      item = new_item(content, attributes, identifier)
-
-      [ item ]
-    end
-
+    [ item ]
   end
-
 end

--- a/lib/data_sources/yardoc.rb
+++ b/lib/data_sources/yardoc.rb
@@ -1,87 +1,79 @@
-# encoding: utf-8
+Class.new(Nanoc::DataSource) do
+  identifier :yard
 
-module NanocSite
-
-  class YARDDataSource < Nanoc::DataSource
-
-    identifier :yard
-
-    def up
-      require 'yard'
-      YARD::Registry.load!('yardoc')
-    end
-
-    def items
-      items = []
-
-      add_filters_to(items)
-      add_helpers_to(items)
-
-      items
-    end
-
-    protected
-
-    def add_filters_to(items)
-      YARD::Registry.at('Nanoc::Filters').children.each do |filter|
-        method        = filter.meths.detect { |m| m.name == :run }
-
-        is_deprecated = !method.tags('deprecated').empty?
-        next if is_deprecated
-
-        slug          = filter.name.to_s.downcase.gsub(/[^a-z0-9]+/, '-')
-        identifiers   = filter['nanoc_identifiers']
-        examples      = method.tags('example').map { |e| { :title => e.name, :code => e.text } }
-
-        options = {}
-        method.tags(:option).map do |t|
-          options[t.pair.name] = t.pair.text
-        end
-
-        items << new_item(
-          '-',
-          {
-            :type        => 'filter',
-            :name        => filter.name,
-            :full_name   => filter.path,
-            :summary     => method.docstring.summary,
-            :description => method.docstring,
-            :identifiers => identifiers,
-            :examples    => examples,
-            :options     => options,
-          },
-          Nanoc::Identifier.new("/filters/_#{slug}", style: :full))
-      end
-    end
-
-    def add_helpers_to(items)
-      YARD::Registry.at('Nanoc::Helpers').children.each do |helper|
-        slug    = helper.name.to_s.downcase.gsub(/^a-z0-9/, '')
-
-        items << new_item(
-          '-',
-          {
-            :type        => 'helper',
-            :name        => helper.name,
-            :full_name   => helper.path,
-            :summary     => helper.docstring.summary,
-            :functions   => helper.meths(:visibility => :public, :included => false).map do |m|
-              signature = "#{m.name}(#{m.parameters.map { |n,v| n }.join(", ")})"
-              if m.tag(:return) && !m.tag(:return).types.empty?
-                signature << " &rarr; #{m.tag(:return).types.first}"
-              end
-              {
-                :name        => m.name,
-                :summary     => m.docstring.summary,
-                :examples    => m.tags('example').map { |e| { :title => e.name, :code => e.text } },
-                :signature   => signature
-              }
-            end,
-          },
-          Nanoc::Identifier.new("/helpers/_#{slug}", style: :full))
-      end
-    end
-
+  def up
+    require 'yard'
+    YARD::Registry.load!('yardoc')
   end
 
+  def items
+    items = []
+
+    add_filters_to(items)
+    add_helpers_to(items)
+
+    items
+  end
+
+  protected
+
+  def add_filters_to(items)
+    YARD::Registry.at('Nanoc::Filters').children.each do |filter|
+      method        = filter.meths.detect { |m| m.name == :run }
+
+      is_deprecated = !method.tags('deprecated').empty?
+      next if is_deprecated
+
+      slug          = filter.name.to_s.downcase.gsub(/[^a-z0-9]+/, '-')
+      identifiers   = filter['nanoc_identifiers']
+      examples      = method.tags('example').map { |e| { :title => e.name, :code => e.text } }
+
+      options = {}
+      method.tags(:option).map do |t|
+        options[t.pair.name] = t.pair.text
+      end
+
+      items << new_item(
+        '-',
+        {
+          :type        => 'filter',
+          :name        => filter.name,
+          :full_name   => filter.path,
+          :summary     => method.docstring.summary,
+          :description => method.docstring,
+          :identifiers => identifiers,
+          :examples    => examples,
+          :options     => options,
+        },
+        Nanoc::Identifier.new("/filters/_#{slug}", style: :full))
+    end
+  end
+
+  def add_helpers_to(items)
+    YARD::Registry.at('Nanoc::Helpers').children.each do |helper|
+      slug    = helper.name.to_s.downcase.gsub(/^a-z0-9/, '')
+
+      items << new_item(
+        '-',
+        {
+          :type        => 'helper',
+          :name        => helper.name,
+          :full_name   => helper.path,
+          :summary     => helper.docstring.summary,
+          :functions   => helper.meths(:visibility => :public, :included => false).map do |m|
+            signature = "#{m.name}(#{m.parameters.map { |n,v| n }.join(", ")})"
+            if m.tag(:return) && !m.tag(:return).types.empty?
+              signature << " &rarr; #{m.tag(:return).types.first}"
+            end
+            {
+              :name        => m.name,
+              :summary     => m.docstring.summary,
+              :examples    => m.tags('example').map { |e| { :title => e.name, :code => e.text } },
+              :signature   => signature
+            }
+          end,
+        },
+        Nanoc::Identifier.new("/helpers/_#{slug}", style: :full))
+    end
+  end
 end

--- a/lib/filters/add_ids_to_headers.rb
+++ b/lib/filters/add_ids_to_headers.rb
@@ -1,24 +1,17 @@
 require 'nokogiri'
 
-module NanocSite
+Class.new(Nanoc::Filter) do
+  identifiers :add_ids_to_headers
 
-  # TODO document
-  class AddIDsToHeadersFilter < Nanoc::Filter
+  def run(content, arguments={})
+    defined_ids = Set.new
 
-    identifiers :add_ids_to_headers
-
-    def run(content, arguments={})
-      defined_ids = Set.new
-
-      doc = Nokogiri::HTML.fragment(content)
-      doc.css("h1, h2, h3, h4, h5, h6").each do |header|
-        id = header.content.downcase.gsub(/\W+/, '-').gsub(/^-|-$/, '')
-        id << '-' while defined_ids.include?(id)
-        header['id'] = id
-      end
-      doc.to_s
+    doc = Nokogiri::HTML.fragment(content)
+    doc.css("h1, h2, h3, h4, h5, h6").each do |header|
+      id = header.content.downcase.gsub(/\W+/, '-').gsub(/^-|-$/, '')
+      id << '-' while defined_ids.include?(id)
+      header['id'] = id
     end
-
+    doc.to_s
   end
-
 end

--- a/lib/filters/add_toc.rb
+++ b/lib/filters/add_toc.rb
@@ -1,34 +1,27 @@
-module NanocSite
+Class.new(Nanoc::Filter) do
+  identifier :add_toc
 
-  # TODO document
-  class AddTOCFilter < Nanoc::Filter
-
-    identifier :add_toc
-
-    def run(content, params={})
-      content.gsub('{{TOC}}') do
-        # Find all top-level sections
-        doc = Nokogiri::HTML(content)
-        headers = doc.xpath('//h2').map do |header|
-          title = header['data-nav-title'] || header.inner_html
-          { :title => title, :id => header['id'] }
-        end
-
-        if headers.empty?
-          next ''
-        end
-
-        # Build table of contents
-        res = '<ol class="toc">'
-        headers.each do |header|
-          res << %[<li><a href="##{header[:id]}">#{header[:title]}</a></li>]
-        end
-        res << '</ol>'
-
-        res
+  def run(content, params={})
+    content.gsub('{{TOC}}') do
+      # Find all top-level sections
+      doc = Nokogiri::HTML(content)
+      headers = doc.xpath('//h2').map do |header|
+        title = header['data-nav-title'] || header.inner_html
+        { :title => title, :id => header['id'] }
       end
+
+      if headers.empty?
+        next ''
+      end
+
+      # Build table of contents
+      res = '<ol class="toc">'
+      headers.each do |header|
+        res << %[<li><a href="##{header[:id]}">#{header[:title]}</a></li>]
+      end
+      res << '</ol>'
+
+      res
     end
-
   end
-
 end

--- a/lib/filters/admonition.rb
+++ b/lib/filters/admonition.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-
-class AdmonitionFilter < Nanoc::Filter
+Class.new(Nanoc::Filter) do
   SUDO_GEM_CONTENT = 'If the <span class="command">{cmd}</span> command fails with a permission error, you likely have to prefix the command with <kbd>sudo</kbd>. Do not use <span class="command">sudo</span> until you have tried the command without it; using <span class="command">sudo</span> when not appropriate will damage your RubyGems installation.'
 
   identifier :admonition

--- a/lib/filters/fixup_whitespace.rb
+++ b/lib/filters/fixup_whitespace.rb
@@ -1,12 +1,8 @@
-# encoding: utf-8
-
-class NanocSite::FixupWhitespace < ::Nanoc::Filter
-
+Class.new(Nanoc::Filter) do
   identifier :fixup_whitespace
 
   def run(content, params={})
     # Necessary because Nokogiri adds a newline
     content.gsub("<li>\n<a href=", '<li><a href=')
   end
-
 end

--- a/lib/filters/link_github_issues.rb
+++ b/lib/filters/link_github_issues.rb
@@ -1,17 +1,10 @@
-module NanocSite
+Class.new(Nanoc::Filter) do
+  identifier :link_github_issues
 
-  # TODO document
-  class LinkGitHubIssuesFilter < Nanoc::Filter
-
-    identifier :link_github_issues
-
-    def run(content, params={})
-      content.gsub(/#(\d+)/) do |m|
-        num = m[1..-1]
-        %[<a href="http://github.com/nanoc/nanoc/issues/#{num}">##{num}</a>]
-      end
+  def run(content, params={})
+    content.gsub(/#(\d+)/) do |m|
+      num = m[1..-1]
+      %[<a href="http://github.com/nanoc/nanoc/issues/#{num}">##{num}</a>]
     end
-
   end
-
 end

--- a/lib/filters/remove_smartness_from_kbd.rb
+++ b/lib/filters/remove_smartness_from_kbd.rb
@@ -1,11 +1,8 @@
-# encoding: utf-8
-
 # Necessary because kramdown does not honor the `kbd` element as an element
 # whose contents should remain preformatted.
 #
 # See https://github.com/gettalong/kramdown/issues/112
-class NanocSite::RemoveSmartnessFromKBD < ::Nanoc::Filter
-
+Class.new(Nanoc::Filter) do
   identifier :remove_smartness_from_kbd
 
   def run(content, params={})
@@ -13,5 +10,4 @@ class NanocSite::RemoveSmartnessFromKBD < ::Nanoc::Filter
     doc.css('kbd').each { |e| e.inner_html = e.inner_html.sub('–', '--') }
     doc.to_s
   end
-
 end

--- a/lib/filters/remove_spacing_around_pre.rb
+++ b/lib/filters/remove_spacing_around_pre.rb
@@ -1,14 +1,7 @@
-module NanocSite
+Class.new(Nanoc::Filter) do
+  identifiers :remove_spacing_around_pre
 
-  # TODO document
-  class RemoveSpacingRoundPreFilter < Nanoc::Filter
-
-    identifiers :remove_spacing_around_pre
-
-    def run(content, arguments={})
-      content.gsub(/<pre( title="[^"]+")?><code( class="language-[a-z]+")?>\n/) { |m| m[0..-2] }
-    end
-
+  def run(content, arguments={})
+    content.gsub(/<pre( title="[^"]+")?><code( class="language-[a-z]+")?>\n/) { |m| m[0..-2] }
   end
-
 end


### PR DESCRIPTION
Rather than explicitly creating classes that are never used, this approach uses `Class.new` to create an anonymous class. **[Best viewed with ?w=1](https://github.com/nanoc/nanoc.ws/pull/118/files?w=1).**

Before:

```
module NanocSite
  class CLIDataSource < Nanoc::DataSource
    identifier :cli
    # …
  end
end
```

After:

```
Class.new(Nanoc::DataSource) do
  identifier :cli
  # …
end
```

It might be worth taking this one step further, and adding a `.define` method on plugin classes:

```
Nanoc::DataSource.define(:cli) do
  # …
end
```