### PR TITLE
Update for Nanoc 4 RC 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git://github.com/nanoc/nanoc.git
-  revision: 1191fedfe0b775553082e24acb17358747023d6d
+  revision: 11fd20c7f8b6a72e593718008b2af8b39ce07ba9
   branch: release-4.0.x
   specs:
     nanoc (4.0.0rc2)
@@ -63,7 +63,7 @@ GEM
     nenv (0.2.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    notiffany (0.0.7)
+    notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
     pry (0.10.1)

--- a/content/doc/identifiers-and-patterns.md
+++ b/content/doc/identifiers-and-patterns.md
@@ -17,11 +17,20 @@ legacy
 
 The following methods are useful for full identifiers:
 
-`identifier.with_ext(string)` &rarr; `String`
-: identifier with the extension replaced with the given string
-
 `identifier.without_ext` &rarr; `String`
-: identifier with the extension removed
+: identifier with the last extension removed
+
+`identifier.without_exts` &rarr; `String`
+: identifier with all extensions removed
+
+`identifier.ext` &rarr; `String`
+: the last extension of this identifier
+
+`identifier.exts` &rarr; `String`
+: all extensions of this identifier
+
+`identifier + string` &rarr; `String`
+: identifier with the given string appended
 
 Here are some examples:
 
@@ -31,17 +40,14 @@ Here are some examples:
     identifier.without_ext
     # => "/about"
 
-    identifier.with_ext('html')
+    identifier + '.html'
     # => "/about.html"
 
-The following methods are useful for legacy identifiers:
+The following method is useful for legacy identifiers:
 
 {: .legacy}
 `identifier.chop` &rarr; `String`
 : identifier with the last character removed
-
-`identifier + string` &rarr; `String`
-: identifier with the given string appended
 
 Here are some examples:
 

--- a/content/doc/nanoc-4-upgrade-guide.md
+++ b/content/doc/nanoc-4-upgrade-guide.md
@@ -34,7 +34,7 @@ NOTE: {sudo-gem-install}
 We recommend using [Bundler](http://bundler.io/) to manage dependencies. When using Bundler, ensure there is a line for Nanoc in the <span class="filename">Gemfile</span> that looks like this:
 
     #!ruby
-    gem 'nanoc', '~> 4.0.0rc2'
+    gem 'nanoc', '~> 4.0.0rc3'
 
 ## Quick upgrade guide
 
@@ -288,7 +288,7 @@ To use identifiers with extensions:
         #!ruby
         route '/**/index.*' do
           # /projects/index.md gets written to /projects/index.html
-          item.identifier.with_ext('html')
+          item.identifier.without_ext + '.html'
         end
 
 6.  Replace calls in the form of `@items['/pattern/'].children` with a call to `#find_all` that matches the children. For example:

--- a/content/doc/reference/variables.md
+++ b/content/doc/reference/variables.md
@@ -108,6 +108,9 @@ The `@item` variable contains the item that is currently being processed. This v
 `@item[:someattribute]` &rarr; _object_
 : The attribute for the given key.
 
+`@item.attributes` &rarr; `Hash`
+: A hash containing all attributes of this item.
+
 `@item.binary?` &rarr; `true` / `false`
 : Whether or not the source content of this item is binary.
 
@@ -177,6 +180,9 @@ The `@layout` variable contains the layout that is currently being used. This va
 
 `@layout[:someattribute]` &rarr; _object_
 : The attribute for the given key.
+
+`@layout.attributes` &rarr; `Hash`
+: A hash containing all attributes of this layout.
 
 `@layout.fetch(:some_key, fallback)` &rarr; _object_
 : The attribute for the given key, or `fallback` if the key is not found.

--- a/content/doc/rules.md
+++ b/content/doc/rules.md
@@ -67,7 +67,7 @@ A `:rep` argument can be passed to the `#route` call. This indicates the name of
 
     #!ruby
     route "/people/**/*", rep: :text do
-      item.identifier.with_ext("txt")
+      item.identifier.without_ext + '.txt'
     end
 
 When a `:snapshot` argument is passed to a routing rule definition, then that routing rule applies to the given snapshot only. The default value for the `:snapshot` argument is `:last`, meaning that compiled items will only be written once they have been fully compiled.
@@ -76,7 +76,7 @@ When a `:snapshot` argument is passed to a routing rule definition, then that ro
 
     #!ruby
     route "/people/**/*", snapshot: :raw do
-      item.identifier.with_ext("txt")
+      item.identifier.without_ext + '.txt'
     end
 
 ## Compilation rules

--- a/lib/helpers/nav_link.rb
+++ b/lib/helpers/nav_link.rb
@@ -33,7 +33,7 @@ class NavLinker
       html_classes << 'home'
     end
 
-    if @item == item || @item.identifier.with_ext('').start_with?(item.identifier.with_ext(''))
+    if @item == item || @item.identifier.without_ext.start_with?(item.identifier.without_ext)
       html_classes << 'active'
     end
 


### PR DESCRIPTION
* Documented
  * `Identifier#without_exts`
  * `Identifier#exts`
  * `Identifier#ext`
  * `#attributes` for `@item` and `@layout`
* Removed `#with_ext` from documentation and code
* Marked identifier + string as non-legacy
* Updated suggested version from rc2 to rc3