### PR TITLE
Fix a few typos

### DIFF
--- a/content/doc/cli.md
+++ b/content/doc/cli.md
@@ -68,4 +68,4 @@ The name of the command is derived from the filename. For example, a command def
 
 Commands can be nested; for example, the command at <span class="filename">commands/foo/bar.rb</span> will be a subcommand of the command at <span class="filename">commands/foo.rb</span>, and can be invoked as <kbd>nanoc foo bar</kbd>.
 
-For details on how to create commands, check out the documentation for [Cri](http://rubydoc.info/gems/cri), the framework used by nanoc for generating commands.
+For details on how to create commands, check out the documentation for [Cri](http://rubydoc.info/gems/cri), the framework used by Nanoc for generating commands.

--- a/content/doc/filters.md
+++ b/content/doc/filters.md
@@ -92,7 +92,7 @@ Here is an example of a filter that resizes images to a given width:
 
 ### Text-to-binary and binary-to-text filters
 
-Filters that convert textual content to binary content or vice versa have the type delcaration `type :text => :binary` or `type :text => :binary`, respectively. For example:
+Filters that convert textual content to binary content or vice versa have the type declaration `type :text => :binary` or `type :text => :binary`, respectively. For example:
 
     #!ruby
     class SampleTextualToBinaryFilter < Nanoc::Filter

--- a/content/doc/guides/creating-multilingual-sites.md
+++ b/content/doc/guides/creating-multilingual-sites.md
@@ -224,7 +224,7 @@ The global `$base_url` variable contains the base URL for the web site. For the 
     #!php
     $base_url = 'http://mystonline.com';
 
-… or you can set the `base_url` confguration attribute in <span class="filename">nanoc.yaml</span> (or <span class="filename">config.yaml</span> for older sites) and generate the PHP code for setting it (a bit icky, but DRYer):
+… or you can set the `base_url` configuration attribute in <span class="filename">nanoc.yaml</span> (or <span class="filename">config.yaml</span> for older sites) and generate the PHP code for setting it (a bit icky, but DRYer):
 
     #!php
     $base_url = '<%= @site.config[:base_url] %>';

--- a/content/doc/guides/using-external-sources.md
+++ b/content/doc/guides/using-external-sources.md
@@ -71,7 +71,7 @@ A data source is responsible for loading data, and is represented by the `Nanoc:
 	  identifier :hr
 	end
 
-Data sources have an `#up` method, which can be overriden to perform actions to establish a connection with the remote data source. In this example, implement it so that it connects to the database:
+Data sources have an `#up` method, which can be overridden to perform actions to establish a connection with the remote data source. In this example, implement it so that it connects to the database:
 
 	#!ruby
 	class HRDataSource < ::Nanoc::DataSource

--- a/content/doc/helpers.md
+++ b/content/doc/helpers.md
@@ -32,7 +32,7 @@ To use this helper, `include` it, for instance in <span class="filename">lib/hel
 	#!ruby
 	include RandomTextHelper
 
-The methods provided by this helper can now be used during filering. For example, the default layout, assuming it is filtered using ERB, can now generate random text like this:
+The methods provided by this helper can now be used during filtering. For example, the default layout, assuming it is filtered using ERB, can now generate random text like this:
 
 	#!erb
 	<p><%%= random_text %></p>

--- a/content/doc/rules.md
+++ b/content/doc/rules.md
@@ -14,7 +14,7 @@ compilation rules
 layouting rules
 : These rules describe the filter that should be used for a given layout.
 
-For every item, Nanoc finds one compiation rule and one routing rule. Similarly, for every layout, Nanoc finds one layouting rule. The first matching rule that is found in the rules file is used. If an item or a layout is not using the correct rule, double-check to make sure that the rules are in the correct order.
+For every item, Nanoc finds one compilation rule and one routing rule. Similarly, for every layout, Nanoc finds one layouting rule. The first matching rule that is found in the rules file is used. If an item or a layout is not using the correct rule, double-check to make sure that the rules are in the correct order.
 
 ## Routing rules
 
@@ -96,7 +96,7 @@ The code block should execute the necessary actions for compiling the item. The 
 * **layout** items, placing their content inside a layout
 * **snapshot** items, remembering their content at that point in time for reuse
 
-The code block does not need to execute anything. An empy `#compile` block will not execute anything.
+The code block does not need to execute anything. An empty `#compile` block will not execute anything.
 
 **Example #1**: The following rule will not perform any actions, i.e. the item will not be filtered nor laid out:
 

--- a/content/doc/sites.md
+++ b/content/doc/sites.md
@@ -28,7 +28,7 @@ A site has the following files and directories:
 : contains the site configuration
 
 <span class="filename">Rules</span>
-: contains compilation, routing and layout rules
+: contains compilation, routing and layouting rules
 
 <span class="filename">content/</span>
 : contains the uncompiled items

--- a/content/doc/sites.md
+++ b/content/doc/sites.md
@@ -28,7 +28,7 @@ A site has the following files and directories:
 : contains the site configuration
 
 <span class="filename">Rules</span>
-: contains compilation, routing and layouting rules
+: contains compilation, routing and layout rules
 
 <span class="filename">content/</span>
 : contains the uncompiled items

--- a/content/doc/troubleshooting.md
+++ b/content/doc/troubleshooting.md
@@ -74,7 +74,7 @@ Nanoc defaults to the current environment encoding, which might not be what you 
 
 * You can set an explicit encoding in the Nanoc configuration file. This is the recommended approach, as it never hurts to be explicit.
 
-To set the encoding explicity in the site configuration, open <span class="filename">nanoc.yaml</span> (or <span class="filename">config.yaml</span> on older Nanoc sites) and navigate to the section where the data sources are defined. Unless you have modified this section, you will find a single entry for the `filesystem` data source there. In this section, add something similar to `encoding: utf-8` (replacing `utf-8` with whatever you really want). It could look like this:
+To set the encoding explicitly in the site configuration, open <span class="filename">nanoc.yaml</span> (or <span class="filename">config.yaml</span> on older Nanoc sites) and navigate to the section where the data sources are defined. Unless you have modified this section, you will find a single entry for the `filesystem` data source there. In this section, add something similar to `encoding: utf-8` (replacing `utf-8` with whatever you really want). It could look like this:
 
 	#!yaml
 	data_sources:

--- a/content/doc/tutorial.md
+++ b/content/doc/tutorial.md
@@ -273,7 +273,7 @@ NOTE: For more information on identifiers, see the [identifiers and patterns](/d
 
 The first rule matches items that have the <span class="filename">html</span> or <span class="filename">md</span> extension. For the `/index.html` item, it assigns the path <span class="filename">/index.html</span>. For the `/about.html` item, it assigns the path <span class="filename">/about/index.html</span>. This approach ensures that all items have clean URLs that do not have the extension in them; you’ll be able to access the about page by going to <span class="uri">/about/</span> rather than <span class="uri">/about.html</span>.
 
-The seond rule matches all other items, and assigns a path that is identical to the identifier. For example, the `/stylesheet.css` item will have the path <span class="filename">/stylesheet.css</span>.
+The second rule matches all other items, and assigns a path that is identical to the identifier. For example, the `/stylesheet.css` item will have the path <span class="filename">/stylesheet.css</span>.
 
 NOTE: For more information on rules, see the [rules](/doc/rules/) page.
 
@@ -343,7 +343,7 @@ Nanoc is bundled with a handful of helpers, including [a tagging helper](/doc/re
 
 This will make all functions defined in the `Nanoc::Helpers::Tagging` module available for use.
 
-Modify the layout and replace the paragraph that dispays the tags with a call to `#tags_for`, which is defined in the tagging helper:
+Modify the layout and replace the paragraph that displays the tags with a call to `#tags_for`, which is defined in the tagging helper:
 
     #!html
     <p>Tags: <%= tags_for(@item) %></p>


### PR DESCRIPTION
I've just discovered Nanoc (I should have known about it sooner as we use it for our API docs :blush:) and was going through the tutorial when I noticed a few typos.

This PR fixes those typos whilst also keeping :gb: English.

I'm not a fan of the word "layouting" - I'd prefer layout - but I understand the meaning and purpose behind it so I've left it as is.