### PR TITLE
Fix spelling and grammar

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -10,7 +10,7 @@ A static-site generator, often abbreviated as <span class="firstterm">SSG</span>
 Nanoc is not:
 
 a <abbr title="content management system">CMS</abbr>
-: It does not help in managing content; it merely processes it. Management of content is usually done on the filesystem.
+: It does not help in managing content; it merely processes it. Management of content is usually done on the file system.
 
 a web application
 : Nanoc is a command-line application. With Nanoc, developing sites happens on a local machine, and the generated site is deployed when it is finished.
@@ -34,7 +34,7 @@ previewable
 versionable
 : Static-site generators commonly store their content in flat text files. This makes them ideal to be used with version control system, such as [Git](http://git-scm.com/). Because of this, many sites built with static-site generators are open-source.
 
-NOTE: Just because static sites are safer than dynamic sites does not mean you don’t need to take security into account. Use strong passwords, don’t communicate credentials over plaintext, etc.
+NOTE: Just because static sites are safer than dynamic sites does not mean you don’t need to take security into account. Use strong passwords, don’t communicate credentials over plain text, etc.
 
 Why use Nanoc?
 --------------
@@ -51,7 +51,7 @@ Nanoc is suitable for a wide variety of sites, including personal blogs, portfol
 
 Some of the sites built with Nanoc include the <a href="https://developer.github.com/">GitHub Developer site</a>, the <a href="http://www.dadt.com/uglybetty/">Ugly Betty site</a> and the <a href="http://guides.spreecommerce.com/api/">Spree Commerce API site</a>.
 
-Programmability combined with free-form metadata is what makes Nanoc flexible. It is agnostic to what content you provide; with metadata you can turn pages into articles, chapters, review, recipes and more, and have them processed in specialised ways. Nothing in Nanoc is predefined, so it gives the power to build sites that meet their goals perfectly.
+Programmability combined with free-form metadata is what makes Nanoc flexible. It is agnostic to what content you provide; with metadata you can turn pages into articles, chapters, review, recipes and more, and have them processed in specialized ways. Nothing in Nanoc is predefined, so it gives the power to build sites that meet their goals perfectly.
 
 Similar projects
 ----------------

--- a/content/contributing.md
+++ b/content/contributing.md
@@ -127,7 +127,7 @@ To announce the new release, follow these steps:
 
 2. Update the release notes on GitHub. Create a new release for the tag, set the release title to the new version number, and copy-paste the release notes into the description field.
 
-3. Send an announcement e-mail to the [Nanoc mailing list](http://groups.google.com/group/nanoc). Include the version number, link to the release notes, instructions for how to update (using plain Rubygems and using Bundler), and instructions on how to report issues. The e-mail template that I often use is based off the following:
+3. Send an announcement e-mail to the [Nanoc mailing list](http://groups.google.com/group/nanoc). Include the version number, link to the release notes, instructions for how to update (using plain RubyGems and using Bundler), and instructions on how to report issues. The e-mail template that I often use is based off the following:
 
    <pre class="template">Hi,
 

--- a/content/doc/cli.md
+++ b/content/doc/cli.md
@@ -22,8 +22,8 @@ aliases: cs
 create a site
 
     Create a new site at the given path. The site will use the compact
-    filesystem data source by default, but this can be changed by
-    using the --datasource commandline option.
+    file system data source by default, but this can be changed by
+    using the --datasource command-line option.
 
 options:
 
@@ -66,6 +66,6 @@ Here is an example command:
 
 The name of the command is derived from the filename. For example, a command defined in <span class="filename">commands/dostuff.rb</span> will have the name `dostuff`, and it can thus be invoked as <kbd>nanoc dostuff</kbd>.
 
-Commands can be nested; for example, the command at <span class="filename">commands/foo/bar.rb</span> will be a subcommand of the command at <span class="filename">commands/foo.rb</span>, and can be invoked as <kbd>nanoc foo bar</kbd>.
+Commands can be nested; for example, the command at <span class="filename">commands/foo/bar.rb</span> will be a sub-command of the command at <span class="filename">commands/foo.rb</span>, and can be invoked as <kbd>nanoc foo bar</kbd>.
 
 For details on how to create commands, check out the documentation for [Cri](http://rubydoc.info/gems/cri), the framework used by Nanoc for generating commands.

--- a/content/doc/deploying.md
+++ b/content/doc/deploying.md
@@ -3,7 +3,7 @@ title: "Deploying Nanoc sites"
 short_title: "Deploying"
 ---
 
-There are quite a few ways to deploy a site to a web host. The most traditional way of uploading a site involves using FTP to transfer the files (perhaps using an “update” or “synchronise” option). If your web host provides access via SSH, you can use SCP or SFTP to deploy a site.
+There are quite a few ways to deploy a site to a web host. The most traditional way of uploading a site involves using FTP to transfer the files (perhaps using an “update” or “synchronize” option). If your web host provides access via SSH, you can use SCP or SFTP to deploy a site.
 
 With rsync
 ----------
@@ -46,9 +46,9 @@ With GitHub Pages or Bitbucket
 
 ### GitHub Pages setup
 
-The publishing of a website based on a Git repo to GitHub Pages is [described in Github's help pages](https://help.github.com/articles/creating-project-pages-manually).
+The publishing of a website based on a Git repository to GitHub Pages is [described in GitHub's help pages](https://help.github.com/articles/creating-project-pages-manually).
 
-Clone the current repo into the <span class="filename">output/</span> directory, create an orphaned branch dedicated to GitHub Pages named `gh-pages`, and check out the new branch:
+Clone the current repository into the <span class="filename">output/</span> directory, create an orphaned branch dedicated to GitHub Pages named `gh-pages`, and check out the new branch:
 
 <pre><span class="prompt">%</span> <kbd>git clone . output</kbd>
 <span class="prompt">%</span> <kbd>cd output</kbd>
@@ -56,7 +56,7 @@ Clone the current repo into the <span class="filename">output/</span> directory,
 <span class="prompt">output@master%</span> <kbd>git checkout gh-pages</kbd>
 <span class="prompt">output@gh-pages%</span> <kbd>cd ..</kbd></pre>
 
-Change the remote for this repo, replacing <var>repo-url</var> with the URL to the repository:
+Change the remote for this repository, replacing <var>repo-url</var> with the URL to the repository:
 
 <pre><span class="prompt">output@gh-pages%</span> <kbd>git remote rm origin</kbd>
 <span class="prompt">output@gh-pages%</span> <kbd>git remote add origin</kbd> <var>repo-url</var></pre>
@@ -65,7 +65,7 @@ Add the <span class="filename">output/</span> directory to your <span class="fil
 
 ### Bitbucket setup
 
-The publishing of a website based on a Git repo to Bitbucket is [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
+The publishing of a website based on a Git repository to Bitbucket is [described in Bitbucket's help pages](https://confluence.atlassian.com/display/BITBUCKET/Publishing+a+Website+on+Bitbucket).
 
 Bitbucket supports publishing a website at <var>username</var>.bitbucket.org, where <var>username</var> is your Bitbucket account name. The contents of the web site will be read from a repository named <var>username</var>.bitbucket.org.
 

--- a/content/doc/filters.md
+++ b/content/doc/filters.md
@@ -108,7 +108,7 @@ Here is an example of an audio synthesis filter:
 
     #!ruby
     class SynthesiseAudio < Nanoc::Filter
-      identifier :synthesise_audio
+      identifier :synthesize_audio
       type :text => :binary
 
       def run(content, params = {})

--- a/content/doc/glossary.md
+++ b/content/doc/glossary.md
@@ -25,7 +25,7 @@ title:    "Glossary"
 	<dd>An object that transforms content from one format into another format. There are filters that evaluate embedded Ruby code (<code>erb</code>, <code>haml</code>), filters that transform from text to HTML (<code>bluecloth</code>, <code>redcloth</code>), filters that “clean” HTML (<code>rubypants</code>), and more.</dd>
 
 	<dt id="glossary-helper">helper</dt>
-	<dd>A module that, when included, offers additional functionality such as easy linking to pages, building XML sitemaps or Atom web feeds.</dd>
+	<dd>A module that, when included, offers additional functionality such as easy linking to pages, building XML site maps or Atom web feeds.</dd>
 
 	<dt id="glossary-identifier">identifier</dt>
 	<dd>A string that is used to uniquely identify an <a href="#glossary-item">item</a> or a <a href="#glossary-layout">layout</a>. It is used to construct <a href="#glossary-path">paths</a> of item <a href="#glossary-representation">representations</a>. <span class="see">See</span> <a href="/doc/identifiers-and-patterns/">identifiers and patterns</a>.</dd>

--- a/content/doc/guides/creating-multilingual-sites.md
+++ b/content/doc/guides/creating-multilingual-sites.md
@@ -9,7 +9,7 @@ Creating a site in multiple languages can be tedious, but Nanoc can nonetheless 
 
 A multilingual site is a site where each page is available in multiple languages. Each language forms some sort of sub-site. For example, the English translation could have pages “About” and “Play,” while the Dutch translation could have matching “Over” and “Speel” pages.
 
-For the Myst Online site, I decided to organise the pages in different languages by creating a top-level directory containing the abbreviated language name (en for English, nl for Dutch, fr for French, etc). Inside the language-specific directory, each page has a path that is also translated (so no /nl/play, but rather /nl/speel). Here’s an example:
+For the Myst Online site, I decided to organize the pages in different languages by creating a top-level directory containing the abbreviated language name (en for English, nl for Dutch, fr for French, etc). Inside the language-specific directory, each page has a path that is also translated (so no /nl/play, but rather /nl/speel). Here’s an example:
 
     /en
       /about

--- a/content/doc/identifiers-and-patterns.md
+++ b/content/doc/identifiers-and-patterns.md
@@ -106,7 +106,7 @@ An example of a regular expression pattern is `%r{\A/projects/(cri|nanoc)\.md\z}
 
 ### Legacy patterns
 
-Legacy patterns are strings that contain wildcard characters. The wildcard characters behave differently than the glob wildchard characters.
+Legacy patterns are strings that contain wildcard characters. The wildcard characters behave differently than the glob wildcard characters.
 
 To enable legacy patterns, set `string_pattern_type` to `"legacy"` in the configuration. For example:
 

--- a/content/doc/installation.md
+++ b/content/doc/installation.md
@@ -46,7 +46,7 @@ If you’re on Windows and are using the Windows console, it’s probably a good
 
 ### Installing from git
 
-You can also install Nanoc from the repository if you want to take advantage of the latest features and improvements in Nanoc. Be warned that the versions from the repository may be unstable, so it is recommended to install Nanoc from rubygems if you want to stay safe. You can install Nanoc from the git repository like this:
+You can also install Nanoc from the repository if you want to take advantage of the latest features and improvements in Nanoc. Be warned that the versions from the repository may be unstable, so it is recommended to install Nanoc from RubyGems if you want to stay safe. You can install Nanoc from the git repository like this:
 
 <pre title="Installing Nanoc from the git repository"><span class="prompt">~%</span> <kbd>git clone git://github.com/nanoc/nanoc.git</kbd>
 <span class="prompt">~%</span> <kbd>cd nanoc</kbd>

--- a/content/doc/items-and-layouts.md
+++ b/content/doc/items-and-layouts.md
@@ -21,7 +21,7 @@ Every item has one or more <span class="firstterm">item representations</span> (
 * a HTML representation, which will be the default for almost all sites
 * a RSS representation, useful for the home page for a blog
 * a JSON representation, so that the site can act as a read-only web API
-* a [cue sheet](http://en.wikipedia.org/wiki/Cue_sheet_%28computing%29) representation, useful for tracklist pages
+* a [cue sheet](http://en.wikipedia.org/wiki/Cue_sheet_%28computing%29) representation, useful for track list pages
 
 An item rep has a name, which usually refers to the format the content is in (`html`, `json`, `rss`, …). Unless otherwise specified, there will be a default representation, aptly named `default`.
 

--- a/content/doc/rules.md
+++ b/content/doc/rules.md
@@ -113,7 +113,7 @@ To filter an item representation, call `#filter` pass the name of the filter as 
       filter :kramdown
     end
 
-Additional parameters can be given to invocations of `#filter`. This is used by some filters, such as the Haml one (`:haml`), to alter filter behaviour in one way or another.
+Additional parameters can be given to invocations of `#filter`. This is used by some filters, such as the Haml one (`:haml`), to alter filter behavior in one way or another.
 
 **Example #3**: The following rule will filter CSS items using the `:relativize_paths` filter, with the filter argument `type` set to `:css`:
 
@@ -228,9 +228,9 @@ This is a shorthand for the following:
     compile '/assets/style/_*' do
     end
 
-## Pre-processing
+## Preprocessing
 
-The <span class="filename">Rules</span> file can contain a `#preprocess` block. This pre-process block is executed before the site is compiled, and has access to all site data.
+The <span class="filename">Rules</span> file can contain a `#preprocess` block. This preprocess block is executed before the site is compiled, and has access to all site data.
 
 Here is an example preprocess block that sets the `author` attribute to `denis` for every article:
 

--- a/content/doc/sites.md
+++ b/content/doc/sites.md
@@ -60,7 +60,7 @@ Compiling site…
 
 Site compiled in 2.42s.</pre>
 
-It is recommended to use [Bundler](http://bundler.io/) with Nanoc sites. When using bundler, compiling a site is done by invoking <span class="command">bundle exec nanoc</span> on the command line.
+It is recommended to use [Bundler](http://bundler.io/) with Nanoc sites. When using Bundler, compiling a site is done by invoking <span class="command">bundle exec nanoc</span> on the command line.
 
 To pass additional options when compiling a site, invoke the <span class="command">nanoc compile</span>, and pass the desired options.
 

--- a/content/doc/troubleshooting.md
+++ b/content/doc/troubleshooting.md
@@ -76,18 +76,19 @@ Nanoc defaults to the current environment encoding, which might not be what you 
 
 To set the encoding explicitly in the site configuration, open <span class="filename">nanoc.yaml</span> (or <span class="filename">config.yaml</span> on older Nanoc sites) and navigate to the section where the data sources are defined. Unless you have modified this section, you will find a single entry for the `filesystem` data source there. In this section, add something similar to `encoding: utf-8` (replacing `utf-8` with whatever you really want). It could look like this:
 
-	#!yaml
-	data_sources:
-	  -
-	    type: filesystem
-	    encoding: utf-8
+```yaml
+data_sources:
+  -
+    type: filesystem
+    encoding: utf-8
+```
 
 For bonus points, you can do all three. Setting up your content, environment and configuration as UTF-8 is the best way to avoid encoding issues now and in the future.
 
 {:data-nav-title="YAML timestamp issues"}
 ## Timestamps in YAML files parsed incorrectly
 
-If you work with datetime attributes (such as `created_at`, `published_at` and `updated_at`) and find that the time is one or more hours off, then this section applies to you.
+If you work with date/time attributes (such as `created_at`, `published_at` and `updated_at`) and find that the time is one or more hours off, then this section applies to you.
 
 If you use timestamps in the `.yaml` file, be sure to include the timezone. If no timezone is specified, then UTC is assumed—not the local time zone! Quoting the [YAML timestamp specification](http://yaml.org/type/timestamp.html):
 

--- a/content/doc/tutorial.md
+++ b/content/doc/tutorial.md
@@ -277,7 +277,7 @@ The second rule matches all other items, and assigns a path that is identical to
 
 NOTE: For more information on rules, see the [rules](/doc/rules/) page.
 
-Now that you know what compilation and routing rules are, we can customise the rules to handle Markdown files. There is a commented-out example compilation rule that fits our purpose. Uncomment the commented-out compilation rule:
+Now that you know what compilation and routing rules are, we can customize the rules to handle Markdown files. There is a commented-out example compilation rule that fits our purpose. Uncomment the commented-out compilation rule:
 
     #!ruby
     compile '/**/*.md' do


### PR DESCRIPTION
This continues where #139 left off. Thanks for the inspiration, @lildude!

My favourite typo is definitely “wildchard”.

This is also an effort at making the spelling a little more consistent. I’ve been mixing US and UK spelling variants, and I think I’ll go for US. (Sorry :gb:)