### PR TITLE
Support for docset

### DIFF
--- a/dashing.json
+++ b/dashing.json
@@ -1,0 +1,13 @@
+{
+    "name": "Nanoc",
+    "package": "nanoc.ws",
+    "index": "output/index.html",
+    "selectors": {
+        "title": "Guide"
+    },
+    "ignore": [
+    ],
+    "icon32x32": "content/assets/images/logo-nav-active.png",
+    "allowJS": false,
+    "ExternalURL": ""
+}


### PR DESCRIPTION
This PR is about adding support for docset to Nanoc.

With tools like [Dash](https://kapeli.com/dash) or [Zeal](https://zealdocs.org) it would be really handy to have access to an offline Nanoc docset. This PR provides a basic Nanoc docset.

I would like to open discussion regarding possible enhancement of this docset by adding support for docset types, see: https://kapeli.com/docsets#supportedentrytypes. Such support would be really easy to do, they will however require to agree on some selectors.

@ddfreyne what do you think?

Best