### PR TITLE
Replace HTML5small with Htmlcompressor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sass', '~> 3.2.13'
 gem 'susy'        # for nice grids
 gem 'systemu'     # for invoking rsync etc
 gem 'yard'        # for loading filter and helper docs
-gem 'html5small'
+gem 'htmlcompressor'
 gem 'nanoc-typohero'
 gem 'w3c_validators'
 gem 'ffi-aspell'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,7 @@ GEM
       nanoc (~> 4.0)
     haml (4.0.7)
       tilt
-    html5small (0.4.0)
-      htmlentities (>= 4.1.0)
-      nokogiri (>= 1.5.0)
-    htmlentities (4.3.4)
+    htmlcompressor (0.3.0)
     json (1.8.3)
     kramdown (1.9.0)
     listen (3.0.5)
@@ -94,7 +91,7 @@ DEPENDENCIES
   ffi-aspell
   guard-nanoc
   haml
-  html5small
+  htmlcompressor
   kramdown
   nanoc (~> 4.1)
   nanoc-typohero

--- a/Rules
+++ b/Rules
@@ -40,14 +40,14 @@ compile '/index.*' do
   filter :erb
   layout '/default.*'
   filter :relativize_paths, type: :html
-  filter :html5small
+  filter :htmlcompressor
   write '/index.html'
 end
 
 compile '/404.*' do
   layout '/default.*'
   filter :typohero
-  filter :html5small
+  filter :htmlcompressor
   write '/404.html'
 end
 
@@ -73,7 +73,7 @@ compile '/**/*' do
   filter :relativize_paths, :type => :html
   filter :fixup_whitespace
   filter :typohero
-  filter :html5small
+  filter :htmlcompressor
 
   if item.binary?
     write item.identifier.to_s

--- a/lib/filters/htmlcompressor.rb
+++ b/lib/filters/htmlcompressor.rb
@@ -1,0 +1,10 @@
+require 'htmlcompressor'
+
+Class.new(Nanoc::Filter) do
+  identifier :htmlcompressor
+
+  def run(content, params = {})
+    compressor = HtmlCompressor::Compressor.new
+    compressor.compress(content)
+  end
+end

--- a/lib/filters/htmlcompressor.rb
+++ b/lib/filters/htmlcompressor.rb
@@ -4,7 +4,27 @@ Class.new(Nanoc::Filter) do
   identifier :htmlcompressor
 
   def run(content, params = {})
-    compressor = HtmlCompressor::Compressor.new
+    compressor = HtmlCompressor::Compressor.new(
+      enabled: true,
+      remove_multi_spaces: true,
+      remove_comments: true,
+      remove_intertag_spaces: true,
+      remove_quotes: true,
+      compress_css: false,
+      compress_javascript: false,
+      simple_doctype: true,
+      remove_script_attributes: false,
+      remove_style_attributes: false,
+      remove_link_attributes: false,
+      remove_form_attributes: false,
+      remove_input_attributes: false,
+      remove_javascript_protocol: false,
+      remove_http_protocol: false,
+      remove_https_protocol: false,
+      preserve_line_breaks: false,
+      simple_boolean_attributes: false,
+      compress_js_templates: false
+    )
     compressor.compress(content)
   end
 end

--- a/lib/filters_.rb
+++ b/lib/filters_.rb
@@ -1,2 +1,1 @@
-require 'html5small/nanoc'
 require 'nanoc-typohero'


### PR DESCRIPTION
This cuts down compilation speed by about half. [Htmlcompressor](https://github.com/paolochiodi/htmlcompressor) is significantly faster than [HTML5small](https://github.com/RubenVerborgh/HTML5small). It does generate slightly larger output, though.

Before:

```
Site compiled in 15.28s.
Site compiled in 14.05s.
Site compiled in 15.88s.
```

After:

```
Site compiled in 7.49s.
Site compiled in 7.21s.
Site compiled in 7.15s.
```