### PR TITLE
Remove Typohero

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,5 @@ gem 'susy'        # for nice grids
 gem 'systemu'     # for invoking rsync etc
 gem 'yard'        # for loading filter and helper docs
 gem 'htmlcompressor'
-gem 'nanoc-typohero'
 gem 'w3c_validators'
 gem 'ffi-aspell'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,9 +45,6 @@ GEM
     mini_portile2 (2.0.0)
     nanoc (4.1.3)
       cri (~> 2.3)
-    nanoc-typohero (1.0.1)
-      nanoc (>= 3.6.7, < 5.0.0)
-      typohero (>= 0.0.4, < 1.0.0)
     nenv (0.2.0)
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
@@ -74,7 +71,6 @@ GEM
     systemu (2.6.5)
     thor (0.19.1)
     tilt (2.0.2)
-    typohero (0.0.5)
     w3c_validators (1.2)
       json
       nokogiri
@@ -94,7 +90,6 @@ DEPENDENCIES
   htmlcompressor
   kramdown
   nanoc (~> 4.1)
-  nanoc-typohero
   nokogiri
   rainpress
   rake

--- a/Rules
+++ b/Rules
@@ -46,7 +46,6 @@ end
 
 compile '/404.*' do
   layout '/default.*'
-  filter :typohero
   filter :htmlcompressor
   write '/404.html'
 end
@@ -72,7 +71,6 @@ compile '/**/*' do
   filter :colorize_syntax, :is_fullpage => true
   filter :relativize_paths, :type => :html
   filter :fixup_whitespace
-  filter :typohero
   filter :htmlcompressor
 
   if item.binary?

--- a/lib/filters_.rb
+++ b/lib/filters_.rb
@@ -1,1 +1,0 @@
-require 'nanoc-typohero'


### PR DESCRIPTION
I already use proper typography manually, and so Typohero does not bring a lot to the table. It occasionally improperly second-guesses my already correct typography.