### PR TITLE
Add dotfiles troubleshooting section

### DIFF
--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -3,7 +3,6 @@ title: "Troubleshooting"
 ---
 
 #section %h[nav-title=“Found 3 content files…”]{Error: “Found 3 content files for X; expected 0 or 1”}
-
   #p This error occurs for legacy identifiers when there are multiple files with the same base name, but different extensions. When using legacy identifiers, Nanoc requires each base name to be unique. For example, the following situation will give raise to this error:
 
   #listing
@@ -15,7 +14,6 @@ title: "Troubleshooting"
   #p New in Nanoc 4 are full identifiers, which contain the file extension. We recommend upgrading to Nanoc 4 and enabling full identifiers as well as glob patterns. For details, see %ref[item=/doc/nanoc-4-upgrade-guide.*]{} and %ref[item=/doc/identifiers-and-patterns.*]{}.
 
 #section %h[nav-title=“Can’t modify frozen…”]{Error: “can’t modify frozen…”}
-
   #p Once the compilation process has started, content, and attributes of layouts and items are %emph{frozen}, which means they cannot be modified anymore. For example, the following rule is invalid and will cause a “can’t modify frozen Array” error:
 
   #listing[lang=ruby]
@@ -35,7 +33,6 @@ title: "Troubleshooting"
     end
 
 #section %h[nav-title=“Textual filters cannot be used…”]{Error: “Textual filters cannot be used on binary items”}
-
   #p There are two item types in Nanoc: textual and binary. Most filters that come with Nanoc, such as %code{:erb} and %code{:haml}, are textual, meaning they take text as input and produce new text. It is also possible to define binary filters, such as an image thumbnail filter.
 
   #p It is not possible to run a textual filter on binary items; for example, running %code{:erb} on an item with filename %filename{content/assets/images/puppy.jpg} will cause the “Textual filters cannot be used on binary items” error.
@@ -43,7 +40,6 @@ title: "Troubleshooting"
   #p When you are getting this error unexpectedly, double-check your Rules file and make sure that no binary item is filtered through a textual filter. Remember that Nanoc will use the first matching rule only!
 
 #section %h{Character encoding issues}
-
   #p Character encoding issues manifest themselves in two ways:
 
   #ul
@@ -86,7 +82,6 @@ title: "Troubleshooting"
     #p For bonus points, you can do all three. Setting up your content, environment, and configuration as UTF-8 is the best way to avoid encoding issues now and in the future.
 
 #section %h[nav-title=YAML timestamp issues]{Timestamps in YAML files parsed incorrectly}
-
   #p If you work with date/time attributes (such as %code{created_at}, %code{published_at}, and %code{updated_at}) and find that the time is one or more hours off, then this section applies to you.
 
   #p If you use timestamps in the YAML file, be sure to include the timezone. If no timezone is specified, then UTC is assumed—not the local time zone! Quoting the %ref[url=http://yaml.org/type/timestamp.html]{YAML timestamp specification}:

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -89,3 +89,17 @@ title: "Troubleshooting"
   #blockquote If the time zone is omitted, the timestamp is assumed to be specified in UTC. The time part may be omitted altogether, resulting in a date format. In such a case, the time part is assumed to be %code{00:00:00Z} (start of day, UTC).
 
   #p We recommend always specifying the time zone.
+
+#section %h{Hidden files are ignored}
+  #p Nanoc intentionally ignores files and directories that have a name that starts with a period. Such files and directories are hidden on Unix-like systems, such as OS X and Linux. Nanoc does so because these hidden files and directories are often generated unintentionally; for instance, OS X will generate %filename{.DS_Store} files, and vim generates backup files with a name like %filename{.about.md.un~}.
+
+  #p To create a hidden file or directory in the output directory of a Nanoc site, ensure that the source file or directory in the %filename{content} directory does not have a name that starts with a period, and create a routing rule that prefixes the name with a period.
+
+  #p For example, to use %ref[url=https://github.com/blog/572-bypassing-jekyll-on-github-pages]{GitHub’s %filename{.nojekyll} file}, which prevents a GitHub site from being processed by Jekyll, create an empty file at %filename{content/nojekyll}, and set up the following rule:
+
+  #listing[lang=ruby]
+    compile '/nojekyll' do
+      write '/.nojekyll'
+    end
+
+  #p After compilation, the output directory will now contain a %filename{output/.nojekyll} file.


### PR DESCRIPTION
Dotfiles are intentionally ignored, but the behavior isn’t always expected.

Fixes nanoc/nanoc/issues/754.

CC @gjtorikian, as you reported the aforementioned issue.