### PR TITLE
Add error runbook

### DIFF
--- a/content/assets/style/_base.scss
+++ b/content/assets/style/_base.scss
@@ -27,6 +27,10 @@ pre, code, kbd, var, samp, .attribute, .command, .output {
     font-size: 13px;
 }
 
+mark {
+  background: $mark-bg-color;
+}
+
 blockquote {
     font-style: italic;
     margin-left: 20px;

--- a/content/assets/style/_code.scss
+++ b/content/assets/style/_code.scss
@@ -32,8 +32,7 @@ pre {
     }
 
     .string, .value {
-        color: #777722;
-        background: #ffffcc;
+        color: #d90;
     }
 
     .constant, .class, .symbol {

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -88,7 +88,7 @@ $tag-wip-bg-color:            $color-dark-60;
 $tag-wip-fg-color:            $color-white;
 $tag-new-bg-color:            $color-blue;
 $tag-new-fg-color:            $color-white;
-$tag-errors-bg-color:         $color-dark-60;
+$tag-errors-bg-color:         $color-orange;
 $tag-errors-fg-color:         $color-white;
 
 // Figures

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -79,6 +79,9 @@ $search-results-selection-bg-color: $color-offwhite-orange;
 $page-bg-color:               $color-white;
 $page-top-border-color:       $color-orange-light;
 
+// Mark
+$mark-bg-color:               #ffffcc;
+
 // Tags
 $tag-legacy-bg-color:         $color-dark-60;
 $tag-legacy-fg-color:         $color-white;

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -88,6 +88,8 @@ $tag-wip-bg-color:            $color-dark-60;
 $tag-wip-fg-color:            $color-white;
 $tag-new-bg-color:            $color-blue;
 $tag-new-fg-color:            $color-white;
+$tag-errors-bg-color:         $color-dark-60;
+$tag-errors-fg-color:         $color-white;
 
 // Figures
 $figure-bg-color:             $color-white;

--- a/content/assets/style/_tags.scss
+++ b/content/assets/style/_tags.scss
@@ -40,6 +40,14 @@ a.wip:after {
     border-radius: 4px;
 }
 
+pre.errors:before {
+    content: "ERRORS";
+
+    background: $tag-errors-bg-color;
+    color: $tag-errors-fg-color;
+    border-top-right-radius: 4px;
+}
+
 pre.legacy:before {
     content: "LEGACY";
 
@@ -64,6 +72,7 @@ pre.new:before {
     border-top-right-radius: 4px;
 }
 
+pre.errors:before,
 pre.legacy:before,
 pre.legacy-intermediate:before,
 pre.new:before {

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -117,3 +117,38 @@ title: "Troubleshooting"
     include Nanoc::Helpers::Blogging
 
   #p Make sure to double-check the spelling of the method that is being invoked.
+
+#section %h{Error: %code{InvalidFormat}}
+  #p This error occurs when Nanoc detects the presence of frontmatter, but the frontmatter isn’t terminated properly. For example, the following file will cause an %code{InvalidFormat} error, because the frontmatter is missing a final %code{---}:
+
+  #listing[errors]
+    ---
+    title: Home
+
+    Here is some content.
+
+  #p To fix this error, terminate the frontmatter properly. For example:
+
+  #listing
+    ---
+    title: Home
+    ---
+
+    Here is some content.
+
+  #p This error can also occur when the file is not supposed to have frontmatter, and the initial %code{---} is meant to be part of the file content. For example, the following will also raise an %code{InvalidFormat} error:
+
+  #listing[errors]
+    ---
+
+    This file starts with three dashes!
+
+  #p To tell Nanoc to treat these three dashes part of the content, rather than signaling the start of the frontmatter, add an artificial empty frontmatter:
+
+  #listing
+    ---
+    ---
+
+    ---
+
+    This file starts with three dashes!

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -152,3 +152,49 @@ title: "Troubleshooting"
     ---
 
     This file starts with three dashes!
+
+#section %h{Error: %code{UnparseableMetadata}}
+  #p This error occurs when the frontmatter is not valid YAML. For example, the following file will cause an %code{UnparseableMetadata} error:
+
+  #listing[errors]
+    ---
+    [Not valid YAML!
+    ---
+
+    Here is some content.
+
+  #p To fix this error, ensure the YAML in the front matter is valid. For example:
+
+  #listing
+    ---
+    %mark{title: Home}
+    ---
+
+    Here is some content.
+
+  #p For more information about YAML, check out the %ref[url=http://yaml.org/YAML_for_ruby.html]{YAML for Ruby} guide, as well as the %ref[url=http://www.yaml.org/spec/1.2/spec.html]{YAML specification}.
+
+  #p This error can also occur when the file is not supposed to have frontmatter, and the initial %code{---} is meant to be part of the file content. For example, the following will also raise an %code{UnparseableMetadata} error:
+
+  #listing
+    ---
+
+    [0, 1[ is the interval that contains all real numbers between zero and one, including zero, but not including one.
+
+    ---
+
+    Another section…
+
+  #p To tell Nanoc to treat these three dashes part of the content, rather than signaling the start of the frontmatter, add an artificial empty frontmatter:
+
+  #listing
+    %mark{---}
+    %mark{---}
+
+    ---
+
+    [0, 1[ is the interval that contains all real numbers between zero and one, including zero, but not including one.
+
+    ---
+
+    Another section…

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -132,7 +132,7 @@ title: "Troubleshooting"
   #listing
     ---
     title: Home
-    ---
+    %mark{---}
 
     Here is some content.
 
@@ -146,8 +146,8 @@ title: "Troubleshooting"
   #p To tell Nanoc to treat these three dashes part of the content, rather than signaling the start of the frontmatter, add an artificial empty frontmatter:
 
   #listing
-    ---
-    ---
+    %mark{---}
+    %mark{---}
 
     ---
 

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -39,7 +39,7 @@ title: "Troubleshooting"
 
   #p When you are getting this error unexpectedly, double-check your Rules file and make sure that no binary item is filtered through a textual filter. Remember that Nanoc will use the first matching rule only!
 
-#section %h{Character encoding issues}
+#section[id=character-encoding-issues] %h{Character encoding issues}
   #p Character encoding issues manifest themselves in two ways:
 
   #ul
@@ -242,3 +242,11 @@ title: "Troubleshooting"
     ---
 
     Another section…
+
+#section %h{Error: %code{InvalidEncoding}}
+  #p This error occurs when the file content cannot be interpreted in the encoding that Nanoc has inferred. For example, the following piece of code will generate a file that will cause an %code{InvalidEncoding} error if Nanoc assumes the file to be encoded as UTF-8:
+
+  #listing[lang=ruby]
+    File.write('content/broken.md', '¿', encoding: 'ISO-8859-1')
+
+  #p See %ref[frag=character-encoding-issues]{} for details on how to fix this issue.

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -176,7 +176,7 @@ title: "Troubleshooting"
 
   #p This error can also occur when the file is not supposed to have frontmatter, and the initial %code{---} is meant to be part of the file content. For example, the following will also raise an %code{UnparseableMetadata} error:
 
-  #listing
+  #listing[errors]
     ---
 
     [0, 1[ is the interval that contains all real numbers between zero and one, including zero, but not including one.
@@ -194,6 +194,50 @@ title: "Troubleshooting"
     ---
 
     [0, 1[ is the interval that contains all real numbers between zero and one, including zero, but not including one.
+
+    ---
+
+    Another section…
+
+#section %h{Error: %code{InvalidMetadata}}
+  #p This error occurs when the frontmatter is not a collection of key-value pairs. For example, the following file will cause an %code{UnparseableMetadata} error:
+
+  #listing[errors]
+    ---
+    My about page
+    ---
+
+    Hello! This page has some details about myself.
+
+  #p To fix this error, ensure the YAML in the front matter is a collection of key-value pairs. For example:
+
+  #listing
+    ---
+    %mark{title:} My about page
+    ---
+
+    Hello! This page has some details about myself.
+
+  #p This error can also occur when the file is not supposed to have frontmatter, and the initial %code{---} is meant to be part of the file content. For example, the following will also raise an %code{UnparseableMetadata} error:
+
+  #listing[errors]
+    ---
+
+    Once upon a time, …
+
+    ---
+
+    Another section…
+
+  #p To tell Nanoc to treat these three dashes part of the content, rather than signaling the start of the frontmatter, add an artificial empty frontmatter:
+
+  #listing
+    %mark{---}
+    %mark{---}
+
+    ---
+
+    Once upon a time, …
 
     ---
 

--- a/lib/dmark_translators/html.rb
+++ b/lib/dmark_translators/html.rb
@@ -59,6 +59,7 @@ class NanocWsHTMLTranslator < NanocWsCommonTranslator
       attributes = {}
 
       attributes[:class] = 'legacy' if element.attributes['legacy']
+      attributes[:class] = 'errors' if element.attributes['errors']
       attributes[:class] = 'legacy-intermediate' if element.attributes['legacy-intermediate']
       attributes[:class] = 'new' if element.attributes['new']
       attributes[:class] = 'spacious' if element.attributes['spacious']
@@ -107,6 +108,7 @@ class NanocWsHTMLTranslator < NanocWsCommonTranslator
 
     pre_classes = []
     pre_classes << 'template' if element.attributes['template']
+    pre_classes << 'errors' if element.attributes['errors']
     pre_classes << 'legacy' if element.attributes['legacy']
     pre_classes << 'legacy-intermediate' if element.attributes['legacy-intermediate']
     pre_classes << 'new' if element.attributes['new']

--- a/lib/dmark_translators/html.rb
+++ b/lib/dmark_translators/html.rb
@@ -55,6 +55,8 @@ class NanocWsHTMLTranslator < NanocWsCommonTranslator
           handle_children(element, context)
         end
       end
+    when 'mark'
+      wrap(element.name) { handle_children(element, context) }
     when 'p', 'dl', 'dt', 'dd', 'code', 'kbd', 'h1', 'h2', 'h3', 'ul', 'ol', 'li', 'figure', 'blockquote', 'var', 'strong', 'section'
       attributes = {}
 


### PR DESCRIPTION
This updates the Troubleshooting section to include specific details about a handful of errors that Nanoc raises. It’s WIP—many errors are not documented yet, but this is a start.