### PR TITLE
Release notes summary

### DIFF
--- a/Checks
+++ b/Checks
@@ -61,7 +61,7 @@ check :spelling do
     'output/doc/reference/config/index.html',
 
     # The release notes contain lots of old, write-once, unmaintained content. Fixing these is a task for later.
-    'output/release-notes/index.html',
+    'output/release-notes/details/index.html',
 
     # The style guide uses nonsensical text.
     'output/style-guide/index.html',

--- a/Rules
+++ b/Rules
@@ -59,7 +59,7 @@ compile '/404.*' do
   write '/404.html'
 end
 
-compile '/release-notes' do
+compile '/release-notes/details.*' do
   filter :fix_contributor_brackets
   filter :kramdown, :auto_ids => false
   filter :add_ids_to_headers

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -20,7 +20,7 @@ short_title: "Deploying"
 
 #p The %code{deploy} section describes %firstterm{deployment targets}, which describe where to deploy to and how to do the deployment. In the example above, the targets are %code{default} and %code{staging}. The %code{kind} attribute describes the deployer to use. In the example above, %code{git} and %code{rsync} are used for the %code{default} and %code{staging} targets, respectively.
 
-#section[id=with-git] %h{With GitHub Pages or Bitbucket}
+#section %h[id=with-git]{With GitHub Pages or Bitbucket}
   #p %ref[url=https://github.com/]{GitHub} and %ref[url=https://bitbucket.org/]{Bitbucket} are two repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
 
   #section %h{GitHub Pages setup}

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -20,7 +20,7 @@ short_title: "Deploying"
 
 #p The %code{deploy} section describes %firstterm{deployment targets}, which describe where to deploy to and how to do the deployment. In the example above, the targets are %code{default} and %code{staging}. The %code{kind} attribute describes the deployer to use. In the example above, %code{git} and %code{rsync} are used for the %code{default} and %code{staging} targets, respectively.
 
-#section %h{With GitHub Pages or Bitbucket}
+#section[id=with-git] %h{With GitHub Pages or Bitbucket}
   #p %ref[url=https://github.com/]{GitHub} and %ref[url=https://bitbucket.org/]{Bitbucket} are two repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
 
   #section %h{GitHub Pages setup}

--- a/content/doc/filters.dmark
+++ b/content/doc/filters.dmark
@@ -20,7 +20,7 @@ title: "Filters"
 
 #p Nanoc comes with a handful of filters. See %ref[item=/doc/reference/filters.*]{} for a list of filters bundled with Nanoc.
 
-#section[id=writing-filters] %h{Writing filters}
+#section %h[id=writing-filters]{Writing filters}
   #p Filters are classes that inherit from %code{Nanoc::Filter}. Writing custom filters is done by subclassing this class and overriding the %code{#run} method, which is responsible for transforming the content.
 
   #p Here is an example (textual) filter that replaces any occurrences of “Nanoc sucks” by “Nanoc rocks”:

--- a/content/doc/filters.dmark
+++ b/content/doc/filters.dmark
@@ -20,7 +20,7 @@ title: "Filters"
 
 #p Nanoc comes with a handful of filters. See %ref[item=/doc/reference/filters.*]{} for a list of filters bundled with Nanoc.
 
-#section %h{Writing filters}
+#section[id=writing-filters] %h{Writing filters}
   #p Filters are classes that inherit from %code{Nanoc::Filter}. Writing custom filters is done by subclassing this class and overriding the %code{#run} method, which is responsible for transforming the content.
 
   #p Here is an example (textual) filter that replaces any occurrences of “Nanoc sucks” by “Nanoc rocks”:

--- a/content/doc/identifiers-and-patterns.dmark
+++ b/content/doc/identifiers-and-patterns.dmark
@@ -4,7 +4,7 @@ title: "Identifiers and patterns"
 
 #p In Nanoc, every item (page or asset) and every layout has a unique %firstterm{identifier}: a string derived from the file’s path. A %firstterm{pattern} is an expression that is used to select items or layouts based on their identifier.
 
-#section[id=identifiers] %h{Identifiers}
+#section %h[id=identifiers]{Identifiers}
   #p Identifiers come in two types: the %emph{full} type, new in Nanoc 4, and the %emph{legacy} type, used in Nanoc 3.
 
   #dl
@@ -71,7 +71,7 @@ title: "Identifiers and patterns"
     #li regular expression patterns
     #li legacy patterns
 
-  #section[id=glob-patterns] %h{Glob patterns}
+  #section %h[id=glob-patterns]{Glob patterns}
     #p Glob patterns are strings that contain wildcard characters. Wildcard characters are characters that can be substituted for other characters in an identifier. An example of a glob pattern is %glob{/projects/*.md}, which matches all files with a %filename{md} extension in the %filename{/projects} directory.
 
     #p Globs are commonplace in Unix-like environments. For example, the Unix command for listing all files with the %filename{md} extension in the current directory is %command{ls *.md}. In this example, the argument to the %command{ls} command is a wildcard.

--- a/content/doc/installation.dmark
+++ b/content/doc/installation.dmark
@@ -41,7 +41,7 @@ nav_title: "Install"
 
   #p If you get a “command not found” error when trying to run %command{nanoc}, you might have to adjust your %code{$PATH} to include the path to the directory where RubyGems installs executables.
 
-  #p The current version of Nanoc is %erb{latest_release_info[:version]}, released on %erb{latest_release_info[:date].format_as_date}. You can find the release notes for this version as well as release notes for older versions on %ref[item=/release-notes]{}.
+  #p The current version of Nanoc is %erb{latest_release_info[:version]}, released on %erb{latest_release_info[:date].format_as_date}. You can find the release notes for this version as well as release notes for older versions on %ref[item=/release-notes.*]{}.
 
   #p If you’re on Windows and are using the Windows console, it’s probably a good idea to install the %productname{win32console} gem using %kbd{gem install win32console} to allow Nanoc to use pretty colors when writing stuff to the terminal.
 

--- a/content/doc/internals.dmark
+++ b/content/doc/internals.dmark
@@ -6,7 +6,7 @@ title: "Internals"
 
 #todo This document is a work in progress. It’s highly incomplete, but will gradually be expanded to include more detail.
 
-#section[id=outdatedness-checking] %h{Outdatedness checking}
+#section %h[id=outdatedness-checking]{Outdatedness checking}
   #p Nanoc is a smart static-site generator; it avoids recompiling items unless necessary.
 
   #p Nanoc will recompile an item if it is deemed to be outdated. The class responsible for determining whether or not an item is outdated is the %code{OutdatednessChecker}. An item is considered as outdated if any of the following conditions hold:

--- a/content/doc/sites.dmark
+++ b/content/doc/sites.dmark
@@ -82,7 +82,7 @@ title: "Sites"
 
   #p You can use %ref[url=https://github.com/guard/guard-nanoc]{%productname{guard-nanoc}} to automatically recompile the site when it changes.
 
-#section %h{Environments}
+#section[id=environments] %h{Environments}
   #p Nanoc supports defining multiple environments in which sites can be compiled. For example, a %code{devel} (development) and a %code{prod} (production) environment, where %code{prod} performs additional work that is typically not needed for local development, such as minifying HTML and CSS, converting all paths to be relative, and cleaning up typography.
 
   #p To specify an environment, pass the %code{-e} or %code{--env} option to the %command{compile} command. For example:

--- a/content/doc/sites.dmark
+++ b/content/doc/sites.dmark
@@ -82,7 +82,7 @@ title: "Sites"
 
   #p You can use %ref[url=https://github.com/guard/guard-nanoc]{%productname{guard-nanoc}} to automatically recompile the site when it changes.
 
-#section[id=environments] %h{Environments}
+#section %h[id=environments]{Environments}
   #p Nanoc supports defining multiple environments in which sites can be compiled. For example, a %code{devel} (development) and a %code{prod} (production) environment, where %code{prod} performs additional work that is typically not needed for local development, such as minifying HTML and CSS, converting all paths to be relative, and cleaning up typography.
 
   #p To specify an environment, pass the %code{-e} or %code{--env} option to the %command{compile} command. For example:

--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -39,7 +39,7 @@ title: "Troubleshooting"
 
   #p When you are getting this error unexpectedly, double-check your Rules file and make sure that no binary item is filtered through a textual filter. Remember that Nanoc will use the first matching rule only!
 
-#section[id=character-encoding-issues] %h{Character encoding issues}
+#section %h[id=character-encoding-issues]{Character encoding issues}
   #p Character encoding issues manifest themselves in two ways:
 
   #ul

--- a/content/doc/tutorial.dmark
+++ b/content/doc/tutorial.dmark
@@ -164,7 +164,7 @@ title: "Tutorial"
 
   #tip If you do not like having a metadata section at the top of every page (perhaps because it breaks syntax highlighting), you can put the metadata in a YAML file with the same name as the page itself. For example, the %filename{content/about.html} page can have its metadata stored in %filename{content/about.yaml} instead.
 
-#section[id=customize-the-layout] %h{Customize the layout}
+#section %h[id=customize-the-layout]{Customize the layout}
   #p The look and feel of a site is defined in layouts. Open the site’s default (and only) layout, %filename{layouts/default.html}, your text editor. It %emph{almost} looks like an HTML page, except for the frontmatter at the top of the file, and eRuby (Embedded Ruby) instructions such as the %code{<%%= yield %%>} one:
 
   #listing[lang=html]
@@ -206,7 +206,7 @@ title: "Tutorial"
 
   #p Recompile the site and open both the home page and the about page. The about page contains a paragraph mentioning John Doe as the author, while the home page does not.
 
-#section[id=write-pages-in-markdown] %h{Write pages in Markdown}
+#section %h[id=write-pages-in-markdown]{Write pages in Markdown}
   #p Nanoc has %firstterm{filters}, which transform content from one format into another.
 
   #p A language that is commonly used instead of HTML is %ref[url=http://daringfireball.net/projects/markdown]{Markdown}. Nanoc comes with several different Markdown filters, including a filter for %ref[url=http://kramdown.gettalong.org/]{kramdown}, a fast and featureful Markdown processor.

--- a/content/release-notes.dmark
+++ b/content/release-notes.dmark
@@ -1,0 +1,44 @@
+---
+title: "Release notes"
+---
+
+#p This page summarizes new features in minor releases. For a detailed list of all changes in all versions, see %ref[item=/release-notes/details.*]{}.
+
+#section %h{Nanoc 4.5}
+  #p Nanoc 4.5 bundles the Git deployer, which used to be in the %ref[url=https://github.com/nanoc/nanoc-git]{%code{nanoc-git} repository}. The %code{nanoc-git} gem can be removed from the %filename{Gemfile}. For details, see %ref[item=/doc/deploying.*,frag=with-git]{}.
+
+#section %h{Nanoc 4.4}
+  #p Nanoc 4.4 adds support for environments. The %command{compile} command now takes an %command{--env} option, e.g. %command{nanoc compile --env=prod}, which sets the %code{NANOC_ENV} environment variable to the given value, and also changes the way the configuration is read.
+
+  #p The configuration can now contain an %code{environments} section, like this:
+
+  #listing[lang=yaml]
+    base_url: http://nanoc.dev
+
+    environments:
+      prod:
+        base_url: http://nanoc.ws
+      staging:
+        base_url: http://staging.nanoc.ws
+
+  #p When an environment is specified on the command line, the data for the environment with the given name will be merged into the top level of the configuration. For example, with %command{--env=prod}, the configuration effectively becomes as follows:
+
+  #listing[lang=yaml]
+    base_url: http://nanoc.ws
+
+  #p For details about environments, see %ref[item=/doc/sites.*,frag=environments]{}.
+
+#section %h{Nanoc 4.3}
+  #p Nanoc 4.3 adds %code{Nanoc::Filter.define}, which makes defining filters a little less verbose:
+
+  #listing[lang=ruby]
+    Nanoc::Filter.define(:censor) do |content, params|
+      content.gsub('Nanoc sucks', 'Nanoc rocks')
+    end
+
+  #p See %ref[item=/doc/filters.*,frag=writing-filters]{} for details.
+
+  #p Additionally, Nanoc will automatically %code{require} all gems defined in the %code{nanoc} group in the %filename{Gemfile}. This is particularly useful for the %code{guard-nanoc} gem, which, when added to the %code{nanoc} group in the %filename{Gemfile}, will add a new %command{live} command to %command{nanoc}. This %command{nanoc live} command simultaneously recompiles the site on changes, and runs a web server. See the %ref[url=https://github.com/guard/guard-nanoc]{%code{guard-nanoc} repository} for details.
+
+#section %h{Nanoc 4.2 and older}
+  #p Release notes are pending. For the time being, see %ref[item=/release-notes/details.*]{}.

--- a/lib/data_sources/release_notes.rb
+++ b/lib/data_sources/release_notes.rb
@@ -1,23 +1,25 @@
 Class.new(Nanoc::DataSource) do
   identifier :release_notes
 
+  CONTENT_PREFIX = "See the [release notes](/release-notes/) page for a summary of new features.\n\n"
+
   def items
     return [] unless defined?(Bundler)
 
     # content
     path = Bundler.rubygems.find_name('nanoc').first.full_gem_path
     raw_content = File.read("#{path}/NEWS.md")
-    content = raw_content.sub(/^#.*$/, '') # remove h1
+    content = CONTENT_PREFIX + raw_content.sub(/^#.*$/, '') # remove h1
 
     # attributes
     attributes = {
-      title: 'Release Notes',
+      title: 'Detailed release notes',
       markdown: 'basic',
       extension: 'md'
     }
 
     # identifier
-    identifier = Nanoc::Identifier.new('/release-notes')
+    identifier = Nanoc::Identifier.new('/release-notes/details.md')
 
     item = new_item(content, attributes, identifier)
 

--- a/lib/dmark_translators/html.rb
+++ b/lib/dmark_translators/html.rb
@@ -35,7 +35,7 @@ class NanocWsHTMLTranslator < NanocWsCommonTranslator
       handle_children(element, context.merge(depth: depth))
     when 'h'
       depth = context.fetch(:depth, 1)
-      id = to_id(text_content_of(element))
+      id = element.attributes['id'] || to_id(text_content_of(element))
 
       attributes = { id: id }
       attributes = attributes.merge('data-nav-title' => element.attributes['nav-title']) if element.attributes['nav-title']

--- a/lib/helpers/release_notes.rb
+++ b/lib/helpers/release_notes.rb
@@ -10,7 +10,7 @@ module NanocSite
       require 'nokogiri'
 
       # Get release notes page
-      content = @items['/release-notes'].compiled_content
+      content = @items['/release-notes/details.*'].compiled_content
       doc = Nokogiri::HTML(content)
 
       # Find and parse usable h2


### PR DESCRIPTION
This moves the release notes to `/release-notes/details`, and converts `/release-notes` to contain a summary of newly added features, along with a short explanation of how to use them.