### PR TITLE
Document InvalidIdentifier-ish errors

### DIFF
--- a/content/doc/troubleshooting.dmark
+++ b/content/doc/troubleshooting.dmark
@@ -352,3 +352,30 @@ title: "Troubleshooting"
     ---
 
     Another section…
+
+#section %h{Error: %code{InvalidIdentifierError}}
+  #p This error occurs when trying to construct an identifier for an item or layout without a leading slash. For instance:
+
+  #listing[errors,lang=ruby]
+    Nanoc::Identifier.new('hello')
+
+  #p To fix this problem, ensure that all identifiers start with a slash:
+
+  #listing[lang=ruby]
+    Nanoc::Identifier.new('/hello')
+
+#section %h{Error: %code{InvalidFullIdentifierError}}
+  #p This error occurs when trying to construct a full identifier for an item or layout with a trailing slash. For instance:
+
+  #listing[errors,lang=ruby]
+    Nanoc::Identifier.new('/hello/')
+
+  #p This issue will not occur with legacy identifier types:
+
+  #listing[lang=ruby]
+    Nanoc::Identifier.new('/hello/', type: :legacy)
+
+  #p To fix this problem, ensure that full identifiers don’t end with a slash:
+
+  #listing[lang=ruby]
+    Nanoc::Identifier.new('/hello')


### PR DESCRIPTION
This PR accompanies nanoc/nanoc/pull/1206/files, and adds an explanation for “invalid identifier” errors:

![screen shot 2017-08-22 at 22 49 08](https://user-images.githubusercontent.com/6269/29586794-2d46482e-878c-11e7-9553-e51366956643.png)
