### PR TITLE
Clarify difference between 3.x/4.x

### DIFF
--- a/content/assets/style/_tags.scss
+++ b/content/assets/style/_tags.scss
@@ -49,7 +49,7 @@ pre.errors:before {
 }
 
 pre.legacy:before {
-  content: "LEGACY";
+  content: "NANOC 3.X";
 
   background: $tag-legacy-bg-color;
   color: $tag-legacy-fg-color;
@@ -57,7 +57,7 @@ pre.legacy:before {
 }
 
 pre.legacy-intermediate:before {
-  content: "LEGACY - INTERMEDIATE";
+  content: "INTERMEDIATE STEP";
 
   background: $tag-legacy-intermediate-bg-color;
   color: $tag-legacy-intermediate-fg-color;
@@ -65,7 +65,7 @@ pre.legacy-intermediate:before {
 }
 
 pre.new:before {
-  content: "NEW";
+  content: "NANOC 4.x";
 
   background: $tag-new-bg-color;
   color: $tag-new-fg-color;


### PR DESCRIPTION
This clarifies what “legacy” and “new” means, by replacing it with “Nanoc 3.x” and “Nanoc 4.x” tags:

![screen shot 2017-08-22 at 23 01 33](https://user-images.githubusercontent.com/6269/29587341-f82e2b3c-878d-11e7-8b16-f088f7a9c7e9.png)
