### PR TITLE
Add GitLab pages deploy documentation

### DIFF
--- a/acceptable_words.txt
+++ b/acceptable_words.txt
@@ -86,6 +86,8 @@ Garnier
 Gemfile
 GitHub
 GitHub's
+GitLab
+GitLab's
 Gitter
 Goodside
 Google

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -67,6 +67,29 @@ short_title: "Deploying"
 
     #p Add the %filename{output/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{output/}.
 
+  #section %h{Automated deployment}
+    #p To deploy the site using the %command{nanoc deploy} command, add a deployment target with the target %code{git} to the Nanoc configuration file (%filename{nanoc.yaml}, or %filename{config.yaml} on older sites):
+
+    #listing[lang=yaml]
+      deploy:
+        default:
+          kind: git
+          branch: gh-pages
+
+    #p For Bitbucket and GitLab, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
+
+  #section %h{Publish}
+    #p To publish a site, compile it and run %command{deploy}:
+
+    #listing
+      %prompt{%%} %kbd{bundle exec nanoc}
+      %prompt{%%} %kbd{bundle exec nanoc deploy}
+
+    #p After a few seconds, the updated site will appear at %uri{http://username.github.io/repo-name} for GitHub, or %uri{http://username.bitbucket.org} for Bitbucket.
+
+    #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
+
+#section %h{With CI pipeline tools}
   #section %h{GitLab CI setup}
     #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}; please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 
@@ -96,28 +119,6 @@ short_title: "Deploying"
       %prompt{%%} %kbd{git push -u origin master}
 
     #p GitLab CI will build and deploy the website. Once it has finished, the site will be accessible at %uri{namespace.gitlab.io}.
-
-  #section %h{Automated deployment}
-    #p To deploy the site using the %command{nanoc deploy} command, add a deployment target with the target %code{git} to the Nanoc configuration file (%filename{nanoc.yaml}, or %filename{config.yaml} on older sites):
-
-    #listing[lang=yaml]
-      deploy:
-        default:
-          kind: git
-          branch: gh-pages
-
-    #p For Bitbucket and GitLab, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
-
-  #section %h{Publish}
-    #p To publish a site, compile it and run %command{deploy}:
-
-    #listing
-      %prompt{%%} %kbd{bundle exec nanoc}
-      %prompt{%%} %kbd{bundle exec nanoc deploy}
-
-    #p After a few seconds, the updated site will appear at %uri{http://username.github.io/repo-name} for GitHub, or %uri{http://username.bitbucket.org} for Bitbucket.
-
-    #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
 
 #section %h{With Netlify}
   #p %ref[url=https://netlify.com/]{Netlify} supports Nanoc out of the box, and deploying onto Netlify is as simple as giving it the Git repository containing your Nanoc site source.

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -134,7 +134,7 @@ short_title: "Deploying"
     #listing
       %prompt{%%} %kbd{git push -u origin master}
 
-    #p GitLab CI will build and deploy the website, it will be accessible at %uri{namespace.gitlab.io}
+    #p GitLab CI will build and deploy the website, it will be accessible at %uri{namespace.gitlab.io}.
 
 #section %h{With Netlify}
   #p %ref[url=https://netlify.com/]{Netlify} supports Nanoc out of the box, and deploying onto Netlify is as simple as giving it the Git repository containing your Nanoc site source.

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -115,7 +115,7 @@ short_title: "Deploying"
         only:
           - master
 
-    #p Push to %var{origin master} to trigger the build:
+    #p Push to trigger the build:
 
     #listing
       %prompt{%%} %kbd{git push -u origin master}

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -90,17 +90,6 @@ short_title: "Deploying"
         only:
           - master
 
-    #p Add the %filename{public/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{public/}.
-
-    #p Create a new Git repository inside the %filename{public/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}):
-
-    #listing
-      %prompt{%%} %kbd{cd public}
-      %prompt{public%%} %kbd{git init}
-      %prompt{public%%} %kbd{git remote add origin} %var{repo-url}
-      %prompt{public%%} %kbd{git add .}
-      %prompt{public%%} %kbd{git commit -m "Added GitLab CI config"}
-
     #p Push to %var{origin master} to trigger the build:
 
     #listing

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -90,6 +90,8 @@ short_title: "Deploying"
     #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
 
 #section %h{With CI pipeline tools}
+  #p It is possible to let CI pipeline tools, such as GitLab CI, perform the compilation and deployment. With this approach, %command{git push} is used rather than a %command{nanoc deploy}.
+
   #section %h{GitLab CI setup}
     #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}; please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -95,7 +95,7 @@ short_title: "Deploying"
     #listing
       %prompt{%%} %kbd{git push -u origin master}
 
-    #p GitLab CI will build and deploy the website, it will be accessible at %uri{namespace.gitlab.io}.
+    #p GitLab CI will build and deploy the website. Once it has finished, the site will be accessible at %uri{namespace.gitlab.io}.
 
   #section %h{Automated deployment}
     #p To deploy the site using the %command{nanoc deploy} command, add a deployment target with the target %code{git} to the Nanoc configuration file (%filename{nanoc.yaml}, or %filename{config.yaml} on older sites):

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -20,11 +20,11 @@ short_title: "Deploying"
 
 #p The %code{deploy} section describes %firstterm{deployment targets}, which describe where to deploy to and how to do the deployment. In the example above, the targets are %code{default} and %code{staging}. The %code{kind} attribute describes the deployer to use. In the example above, %code{git} and %code{rsync} are used for the %code{default} and %code{staging} targets, respectively.
 
-#section %h[id=with-git]{With GitHub Pages, GitLab Pages or Bitbucket}
-  #p %ref[url=https://github.com/]{GitHub}, %ref[url=https://gitlab.com/]{GitLab} and %ref[url=https://bitbucket.org/]{Bitbucket} are repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
+#section %h[id=with-git]{With GitHub Pages or Bitbucket}
+  #p %ref[url=https://github.com/]{GitHub} and %ref[url=https://bitbucket.org/]{Bitbucket} are repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
 
   #section %h{Disable %filename{.git} pruning}
-    #p Because GitHub Pages, GitLab Pages or Bitbucket all use Git to publish, it’s important to prevent the %filename{.git} directory from being pruned away. In %filename{nanoc.yaml}, look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
+    #p Because GitHub Pages and Bitbucket both use Git to publish, it’s important to prevent the %filename{.git} directory from being pruned away. In %filename{nanoc.yaml}, look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
 
     #listing[lang=yaml]
       prune:
@@ -76,7 +76,7 @@ short_title: "Deploying"
           kind: git
           branch: gh-pages
 
-    #p For Bitbucket and GitLab, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
+    #p For Bitbucket, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
 
   #section %h{Publish}
     #p To publish a site, compile it and run %command{deploy}:

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -67,8 +67,8 @@ short_title: "Deploying"
 
     #p Add the %filename{output/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{output/}.
 
-  #section %h{GitLab Pages setup}
-    #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}, please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
+  #section %h{GitLab CI setup}
+    #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}; please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 
     #p GitLab supports publishing a website at %uri{namespace.gitlab.io}, where %var{namespace} is your GitLab account or group name. The contents of the website will be read from a repository named %uri{namespace.gitlab.io}.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -66,28 +66,6 @@ short_title: "Deploying"
 
     #p Add the %filename{output/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{output/}.
 
-  #section %h{Automated deployment}
-    #p To deploy the site using the %command{nanoc deploy} command, add a deployment target with the target %code{git} to the Nanoc configuration file (%filename{nanoc.yaml}, or %filename{config.yaml} on older sites):
-
-    #listing[lang=yaml]
-      deploy:
-        default:
-          kind: git
-          branch: gh-pages
-
-    #p For Bitbucket, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
-
-  #section %h{Publish}
-    #p To publish a site, compile it and run %command{deploy}:
-
-    #listing
-      %prompt{%%} %kbd{bundle exec nanoc}
-      %prompt{%%} %kbd{bundle exec nanoc deploy}
-
-    #p After a few seconds, the updated site will appear at %uri{http://username.github.io/repo-name} for GitHub, or %uri{http://username.bitbucket.org} for Bitbucket.
-
-    #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
-
   #section %h{GitLab Pages setup}
     #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}, please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 
@@ -134,6 +112,28 @@ short_title: "Deploying"
       %prompt{%%} %kbd{git push -u origin master}
 
     #p GitLab CI will build and deploy the website, it will be accessible at %uri{namespace.gitlab.io}.
+
+  #section %h{Automated deployment}
+    #p To deploy the site using the %command{nanoc deploy} command, add a deployment target with the target %code{git} to the Nanoc configuration file (%filename{nanoc.yaml}, or %filename{config.yaml} on older sites):
+
+    #listing[lang=yaml]
+      deploy:
+        default:
+          kind: git
+          branch: gh-pages
+
+    #p For Bitbucket, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
+
+  #section %h{Publish}
+    #p To publish a site, compile it and run %command{deploy}:
+
+    #listing
+      %prompt{%%} %kbd{bundle exec nanoc}
+      %prompt{%%} %kbd{bundle exec nanoc deploy}
+
+    #p After a few seconds, the updated site will appear at %uri{http://username.github.io/repo-name} for GitHub, or %uri{http://username.bitbucket.org} for Bitbucket.
+
+    #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
 
 #section %h{With Netlify}
   #p %ref[url=https://netlify.com/]{Netlify} supports Nanoc out of the box, and deploying onto Netlify is as simple as giving it the Git repository containing your Nanoc site source.

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -73,7 +73,7 @@ short_title: "Deploying"
 
     #p First of all, create a GitLab project corresponding to your GitLab website address, e.g. %uri{ddfreyne.gitlab.io}.
 
-    #p GitLab Pages only serves content from the %filename{public} directory, make sure to rename %filename{output} to %filename{public} and change the value of %var{output_dir} to %var{public}.
+    #p GitLab Pages only serves content from the %filename{public/} directory, so rename the %filename{output/} directory to %filename{public/} and change the value of %code{output_dir} in %filename{nanoc.yaml} to %var{public}.
 
     #p Create a %filename{.gitlab-ci.yml} file with the following content:
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -122,6 +122,24 @@ short_title: "Deploying"
 
     #p GitLab CI will build and deploy the website. Once it has finished, the site will be accessible at %uri{namespace.gitlab.io}.
 
+    #section %h{Setting up checks}
+      #p To run deployment checks, add %code{bundle exec nanoc check --deploy} to the %filename{.gitlab-ci.yml} file, after %code{bundle exec nanoc}:
+
+      #listing[lang=yaml]
+        image: ruby:2.4
+        pages:
+          script:
+            - bundle install -j4
+            - bundle exec nanoc
+            - bundle exec nanoc check --deploy
+          artifacts:
+            paths:
+              - public
+          only:
+            - master
+
+    #p A deploy will now only succeed if checks pass.
+
 #section %h{With Netlify}
   #p %ref[url=https://netlify.com/]{Netlify} supports Nanoc out of the box, and deploying onto Netlify is as simple as giving it the Git repository containing your Nanoc site source.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -117,7 +117,7 @@ short_title: "Deploying"
           kind: git
           branch: gh-pages
 
-    #p For Bitbucket, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
+    #p For Bitbucket and GitLab, set %code{branch} to %code{master}, and for GitHub, set it to %code{gh-pages}.
 
   #section %h{Publish}
     #p To publish a site, compile it and run %command{deploy}:

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -94,10 +94,11 @@ short_title: "Deploying"
     #p Create a new Git repository inside the %filename{public/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}):
 
     #listing
-      %prompt{%%} %kbd{git init}
-      %prompt{%%} %kbd{git remote add origin} %var{repo-url}
-      %prompt{%%} %kbd{git add .}
-      %prompt{%%} %kbd{git commit -m "Added GitLab CI config"}
+      %prompt{%%} %kbd{cd public}
+      %prompt{public%%} %kbd{git init}
+      %prompt{public%%} %kbd{git remote add origin} %var{repo-url}
+      %prompt{public%%} %kbd{git add .}
+      %prompt{public%%} %kbd{git commit -m "Added GitLab CI config"}
 
     #p Ensure that the %filename{.git} directory is excluded from pruning. This is the default, but some sites might override this option. In %filename{nanoc.yaml} (or %filename{config.yaml} on older sites), look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -83,7 +83,7 @@ short_title: "Deploying"
       pages:
         script:
           - bundle install -j4
-          - nanoc
+          - bundle exec nanoc
         artifacts:
           paths:
             - public

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -91,7 +91,7 @@ short_title: "Deploying"
 
     #p Add the %filename{public/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{public/}.
 
-    #p Create a new Git repository inside the %filename{/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}) :
+    #p Create a new Git repository inside the %filename{/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}):
 
     #listing
       %prompt{%%} %kbd{git init}

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -23,6 +23,14 @@ short_title: "Deploying"
 #section %h[id=with-git]{With GitHub Pages, GitLab Pages or Bitbucket}
   #p %ref[url=https://github.com/]{GitHub}, %ref[url=https://gitlab.com/]{GitLab} and %ref[url=https://bitbucket.org/]{Bitbucket} are repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
 
+  #section %h{Disable %filename{.git} pruning}
+    #p Because GitHub Pages, GitLab Pages or Bitbucket all use Git to publish, it’s important to prevent the %filename{.git} directory from being pruned away. In %filename{nanoc.yaml}, look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
+
+    #listing[lang=yaml]
+      prune:
+        auto_prune: true
+        exclude: [ '.git' ]
+
   #section %h{GitHub Pages setup}
     #p The publishing of a website based on a Git repository to GitHub Pages is %ref[url=https://help.github.com/articles/creating-project-pages-manually]{described in GitHub's help pages}.
 
@@ -42,13 +50,6 @@ short_title: "Deploying"
       %prompt{output@gh-pages%%} %kbd{git remote add origin} %var{repo-url}
 
     #p Add the %filename{output/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain the %filename{output/} directory.
-
-    #p Ensure that the %filename{.git} directory is excluded from pruning. This is the default, but some sites might override this option. In %filename{nanoc.yaml} (or %filename{config.yaml} on older sites), look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
-
-    #listing[lang=yaml]
-      prune:
-        auto_prune: true
-        exclude: [ '.git' ]
 
   #section %h{Bitbucket setup}
     #p The publishing of a website based on a Git repository to Bitbucket is %ref[url=https://confluence.atlassian.com/bitbucket/publishing-a-website-on-bitbucket-cloud-221449776.html]{described in Bitbucket's help pages}.
@@ -99,13 +100,6 @@ short_title: "Deploying"
       %prompt{public%%} %kbd{git remote add origin} %var{repo-url}
       %prompt{public%%} %kbd{git add .}
       %prompt{public%%} %kbd{git commit -m "Added GitLab CI config"}
-
-    #p Ensure that the %filename{.git} directory is excluded from pruning. This is the default, but some sites might override this option. In %filename{nanoc.yaml} (or %filename{config.yaml} on older sites), look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
-
-    #listing[lang=yaml]
-      prune:
-        auto_prune: true
-        exclude: [ '.git' ]
 
     #p Push to %var{origin master} to trigger the build:
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -97,7 +97,7 @@ short_title: "Deploying"
 
     #p GitLab Pages only serves content from the %filename{public} directory, make sure to rename %filename{output} to %filename{public} and change the value of %var{output_dir} to %var{public}.
 
-    #p Create a %filename{.gitlab-ci.yml} file with the followin content:
+    #p Create a %filename{.gitlab-ci.yml} file with the following content:
 
     #listing[lang=yaml]
       image: ruby:2.4

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -20,8 +20,8 @@ short_title: "Deploying"
 
 #p The %code{deploy} section describes %firstterm{deployment targets}, which describe where to deploy to and how to do the deployment. In the example above, the targets are %code{default} and %code{staging}. The %code{kind} attribute describes the deployer to use. In the example above, %code{git} and %code{rsync} are used for the %code{default} and %code{staging} targets, respectively.
 
-#section %h[id=with-git]{With GitHub Pages or Bitbucket}
-  #p %ref[url=https://github.com/]{GitHub} and %ref[url=https://bitbucket.org/]{Bitbucket} are two repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
+#section %h[id=with-git]{With GitHub Pages, GitLab Pages or Bitbucket}
+  #p %ref[url=https://github.com/]{GitHub}, %ref[url=https://gitlab.com/]{GitLab} and %ref[url=https://bitbucket.org/]{Bitbucket} are repository hosting services that support publishing websites. This section explains how to use their functionality for publishing a website in combination with Nanoc.
 
   #section %h{GitHub Pages setup}
     #p The publishing of a website based on a Git repository to GitHub Pages is %ref[url=https://help.github.com/articles/creating-project-pages-manually]{described in GitHub's help pages}.
@@ -87,6 +87,54 @@ short_title: "Deploying"
     #p After a few seconds, the updated site will appear at %uri{http://username.github.io/repo-name} for GitHub, or %uri{http://username.bitbucket.org} for Bitbucket.
 
     #p For GitHub, we recommend removing the %code{gh-pages} branch from the base repository, since it is likely to be out of sync with the %code{gh-pages} branch in the repository in the %filename{output/} directory.
+
+  #section %h{GitLab Pages setup}
+    #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}, please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
+
+    #p GitLab supports publishing a website at %uri{namespace.gitlab.io}, where %var{namespace} is your GitLab account or group name. The contents of the website will be read from a repository named %uri{namespace.bitbucket.io}.
+
+    #p First of all, create a GitLab project corresponding to your GitLab website address, e.g. %uri{ddfreyne.gitlab.io}.
+
+    #p GitLab Pages only serves content from the %filename{public} directory, make sure to rename %filename{output} to %filename{public} and change the value of %var{output_dir} to %var{public}.
+
+    #p Create a %filename{.gitlab-ci.yml} file with the followin content:
+
+    #listing[lang=yaml]
+      image: ruby:2.4
+      pages:
+        script:
+        - bundle install -j4
+        - nanoc
+        artifacts:
+          paths:
+          - public
+        only:
+        - master
+
+    #p Add the %filename{public/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{public/}.
+
+    #p Create a new Git repository inside the %filename{/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}) :
+
+    #listing
+      %prompt{%%} %kbd{git init}
+      %prompt{%%} %kbd{git remote add origin} %var{repo-url}
+      %prompt{%%} %kbd{git add .}
+      %prompt{%%} %kbd{git commit -m "Added GitLab CI config"}
+
+
+    #p Ensure that the %filename{.git} directory is excluded from pruning. This is the default, but some sites might override this option. In %filename{nanoc.yaml} (or %filename{config.yaml} on older sites), look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
+
+    #listing[lang=yaml]
+      prune:
+        auto_prune: true
+        exclude: [ '.git' ]
+
+    #p Push to %var{origin master} to trigger the build:
+
+    #listing
+      %prompt{%%} %kbd{git push -u origin master}
+
+    #p GitLab CI will build and deploy the website, it will be accessible at %uri{namespace.gitlab.io}
 
 #section %h{With Netlify}
   #p %ref[url=https://netlify.com/]{Netlify} supports Nanoc out of the box, and deploying onto Netlify is as simple as giving it the Git repository containing your Nanoc site source.

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -121,7 +121,6 @@ short_title: "Deploying"
       %prompt{%%} %kbd{git add .}
       %prompt{%%} %kbd{git commit -m "Added GitLab CI config"}
 
-
     #p Ensure that the %filename{.git} directory is excluded from pruning. This is the default, but some sites might override this option. In %filename{nanoc.yaml} (or %filename{config.yaml} on older sites), look for a %code{prune} section, and if it exists, ensure that it has an %code{exclude} configuration option, and that it includes %code{.git}. The following is a correct set-up:
 
     #listing[lang=yaml]

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -93,7 +93,7 @@ short_title: "Deploying"
   #p It is possible to let CI pipeline tools, such as GitLab CI, perform the compilation and deployment. With this approach, %command{git push} is used rather than a %command{nanoc deploy}.
 
   #section %h{GitLab CI setup}
-    #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}; please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
+    #p The publishing of a website based on a Git repository to %ref[url=https://gitlab.com/]{GitLab} is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab Pages’s documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}; please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 
     #p GitLab supports publishing a website at %uri{namespace.gitlab.io}, where %var{namespace} is your GitLab account or group name. The contents of the website will be read from a repository named %uri{namespace.gitlab.io}.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -69,7 +69,7 @@ short_title: "Deploying"
   #section %h{GitLab Pages setup}
     #p The publishing of a website based on a Git repository to GitLab Pages is %ref[url=https://docs.gitlab.com/ee/user/project/pages/index.html]{described in GitLab's documentation pages}. This guide assumes you are deploying to %uri{gitlab.com}, please follow this %ref[url=https://docs.gitlab.com/ee/administration/pages/index.html]{documentation} if you are running your own GitLab instance.
 
-    #p GitLab supports publishing a website at %uri{namespace.gitlab.io}, where %var{namespace} is your GitLab account or group name. The contents of the website will be read from a repository named %uri{namespace.bitbucket.io}.
+    #p GitLab supports publishing a website at %uri{namespace.gitlab.io}, where %var{namespace} is your GitLab account or group name. The contents of the website will be read from a repository named %uri{namespace.gitlab.io}.
 
     #p First of all, create a GitLab project corresponding to your GitLab website address, e.g. %uri{ddfreyne.gitlab.io}.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -82,13 +82,13 @@ short_title: "Deploying"
       image: ruby:2.4
       pages:
         script:
-        - bundle install -j4
-        - nanoc
+          - bundle install -j4
+          - nanoc
         artifacts:
           paths:
-          - public
+            - public
         only:
-        - master
+          - master
 
     #p Add the %filename{public/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{public/}.
 

--- a/content/doc/deploying.dmark
+++ b/content/doc/deploying.dmark
@@ -91,7 +91,7 @@ short_title: "Deploying"
 
     #p Add the %filename{public/} directory to your %filename{.gitignore}. Make sure that the base repository doesn’t contain %filename{public/}.
 
-    #p Create a new Git repository inside the %filename{/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}):
+    #p Create a new Git repository inside the %filename{public/} directory of your Nanoc website, replacing %var{repo-url} with the URL to the repository (e.g. %code{git@gitlab.com:ddfreyne/ddfreyne.gitlab.io.git}):
 
     #listing
       %prompt{%%} %kbd{git init}


### PR DESCRIPTION
This is based off @abuango’s #207, with minor modifications (in particular, moving the instructions to a new “With CI pipeline tools” section).

* [ ] Clean up commit history (squash?)
* [x] Integrate with `nanoc check --deploy`