### PR TITLE
Fix example for external_links check config.

### DIFF
--- a/content/doc/reference/config.dmark
+++ b/content/doc/reference/config.dmark
@@ -94,5 +94,5 @@ title: "Configuration"
     #listing[lang=yaml]
       checks:
         external_links:
-          exclude: ['^/server_status']
+          exclude: ['^https?://example.com/']
           exclude_files: ['blog/page']


### PR DESCRIPTION
The `exclude` example is copied over from the *internal_links* example, so it won't exclude links to `example.com`.

Feel free to come up with a better regular expression for that purpose!

Signed-off-by: Thomas Hochstein <thh@inter.net>