### PR TITLE
Increase contrast in code blocks

### DIFF
--- a/content/assets/style/_base.scss
+++ b/content/assets/style/_base.scss
@@ -33,11 +33,8 @@ p {
 }
 
 pre {
-  border-radius: 4px;
-
-  box-shadow: 0 1px 1px $pre-shadow-color;
-
-  background: $pre-bg-color;
+  border: 1px solid $pre-border-color;
+  box-shadow: 3px 3px 0 $pre-shadow-color;
 
   padding: 10px;
   margin: 0 0 20px 0;

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -61,7 +61,7 @@ $link-color-hover:            $color-white;
 $link-disabled:               $color-dark-60;
 
 // Code
-$pre-bg-color:                $color-offwhite;
+$pre-border-color:            rgba(0, 0, 0, 0.5);
 $pre-shadow-color:            rgba(0, 0, 0, 0.3);
 $code-prompt-color:           rgba(0, 0, 0, 0.5);
 


### PR DESCRIPTION
Before:

<img width="726" alt="screen shot 2018-01-26 at 13 06 47" src="https://user-images.githubusercontent.com/6269/35439246-3824b3f0-029a-11e8-9db0-6b3c2e0a1e30.png">

After:

<img width="723" alt="screen shot 2018-01-26 at 13 06 36" src="https://user-images.githubusercontent.com/6269/35439254-3cf5126c-029a-11e8-97fb-efc40abf4bd0.png">

Advantages:

* The rounding and subtle shadow elements are not found elsewhere on the site.
* The contrast is higher now.
* The beige background is used for other parts of the site, which are not related.

Concerns:

* Is it too high-contrast in comparison to other parts of the site?
* Could/should admonitions use a similar square-with-sharp-shadow style?