### PR TITLE
Rewrite testing guide

### DIFF
--- a/content/doc/testing.dmark
+++ b/content/doc/testing.dmark
@@ -1,43 +1,23 @@
 ---
-title: "Testing Nanoc sites"
-short_title: "Testing"
+title: "Checking correctness Nanoc sites"
+short_title: "Checking"
 ---
 
-#p The %command{check} command is used to verify that a compiled site meets the requirements.
+#p Nanoc comes with tooling for ensuring that your site has no errors, such as broken links, stale files in the output directory, and mixed HTTP/HTTPS content. Such checks can be run:
 
-#p A check can be run using %kbd{nanoc check %var{check-name}}. For instance, the following will run the internal links check (%code{internal_links} or %code{ilinks}):
+#ul
+  #li manually, using the %command{check} command
+  #li automatically, as part of the deployment process (invoked by the %command{deploy} command)
 
-#listing
-  %prompt{%%} %kbd{nanoc check ilinks}
-  Loading site data… done
-    Running internal_links check…   %log-check-ok{ok}
-  %prompt{%%}
+#section %h{Running checks manually}
+  #p To run a single check, run the %command{check} with the name of the check as an argument:
 
-#section %h{Available checks}
-  #p Nanoc comes with the following checks:
+  #listing
+    %prompt{%%} %kbd{nanoc check ilinks}
+    Loading site data… done
+      Running internal_links check…   %log-check-ok{ok}
 
-  #dl
-    #dt %code{css}
-    #dd verifies that the CSS is valid
-
-    #dt %code{html}
-    #dd verifies that the HTML is valid
-
-    #dt %code{external_links}
-    #dt %code{elinks}
-    #dd verifies that external links are correct
-
-    #dt %code{internal_links}
-    #dt %code{ilinks}
-    #dd verifies that internal links are correct
-
-    #dt %code{stale}
-    #dd verifies whether no non-Nanoc items are in the output directory
-
-    #dt %code{mixed_content}
-    #dd verifies that no content is included or linked to from a potentially insecure source
-
-#section %h{Deployment-time checks}
+#section %h{Running checks before deploying}
   #p A file named %filename{Checks} at the root of a Nanoc site defines which checks should be run before a %kbd{nanoc deploy}.
 
   #p Here is an example %filename{Checks} file that ensures that a Nanoc site does not get deployed if there are broken internal links or stale files in the output directory:
@@ -73,7 +53,7 @@ short_title: "Testing"
 
   #p To run the checks marked for deployment without deploying, use %kbd{nanoc check --deploy}.
 
-#section %h{Custom checks}
+#section %h{Defining custom checks}
   #p The %filename{Checks} file is also used to define custom checks. Here is an example check that verifies that no compiled files contain %code{<%%} and therefore likely include unprocessed ERB instructions:
 
   #listing[lang=ruby]
@@ -88,3 +68,27 @@ short_title: "Testing"
   #p In a custom check, you can use %code{#add_issue}. The first argument is the description of the problem, and the %code{:subject} option defines the location of the problem (usually a filename).
 
   #p In a custom check, the variables %code{@config}, %code{@items}, and %code{@layouts} are available, in addition to %code{@output_filenames}, which is the collection of filenames in the output directory that correspond to an item in the site. For details, see %ref[item=/doc/reference/variables.*]{}.
+
+#section %h{Available checks}
+  #p Nanoc comes with the following checks:
+
+  #dl
+    #dt %code{css}
+    #dd verifies that the CSS is valid
+
+    #dt %code{html}
+    #dd verifies that the HTML is valid
+
+    #dt %code{external_links}
+    #dt %code{elinks}
+    #dd verifies that external links are correct
+
+    #dt %code{internal_links}
+    #dt %code{ilinks}
+    #dd verifies that internal links are correct
+
+    #dt %code{stale}
+    #dd verifies whether no non-Nanoc items are in the output directory
+
+    #dt %code{mixed_content}
+    #dd verifies that no content is included or linked to from a potentially insecure source


### PR DESCRIPTION
* Consistently refer to checking as “checking” (not testing)
* Make intro paragraph more exciting
* Move “Available checks” to the bottom
* Change section titles to reflect purpose