### PR TITLE
Sass improvements

### DIFF
--- a/content/doc/guides/using-common-filters.dmark
+++ b/content/doc/guides/using-common-filters.dmark
@@ -56,7 +56,7 @@ title: "Using common filters"
       [:default, :sourcemap].each do |rep_name|
         compile '/css/**/*.sass', rep: rep_name do
           path = @item.identifier.without_ext + '.css'
-          options = { syntax: :sass, style: :compact, sourcemap_path: path + '.map' %}
+          options = { syntax: :sass, style: :compact, css_path: path, sourcemap_path: path + '.map' %}
 
           case rep_name
           when :default

--- a/content/doc/guides/using-common-filters.dmark
+++ b/content/doc/guides/using-common-filters.dmark
@@ -71,6 +71,16 @@ title: "Using common filters"
 
     #p When using the %code{:sass_sourcemap} filter, be sure to invoke it with the same options as the %code{:sass} filter.
 
+    #p The %code{:sass} filter also supports generating inline source maps:
+
+    #listing[lang=ruby]
+      compile '/css/**/*.scss'
+        path = @item.identifier.without_ext + '.css'
+        options = { syntax: :sass, style: :compact, css_path: path, sourcemap_path: :inline %}
+
+        filter :sass, options
+      end
+
   #section %h{Using %code{nanoc()} in Sass}
     #p Nanoc’s Sass filter defines a %code{nanoc()} Sass function, which allows you to evaluate Ruby code from Sass within the compilation context. It takes a string containing Ruby code.
 

--- a/content/doc/reference/filters.dmark
+++ b/content/doc/reference/filters.dmark
@@ -529,7 +529,8 @@ title: "Filters"
   #p The %code{:sass_sourcemap} filter produces a source map for a rendered %ref[url=http://sass-lang.com/]{Sass} stylesheet. For example:
 
   #listing[lang=ruby]
-    filter :sass_sourcemap, sourcemap_path: @item.identifier.without_ext + '.css.map'
+    path = @item.identifier.without_ext + '.css'
+    filter :sass_sourcemap, css_path: path, sourcemap_path: path + '.map'
 
   #p Both %code{:sass} and %code{:sass_sourcemap} filters must be passed the same options.
 


### PR DESCRIPTION
This PR documents 2 things related to `:sass` and `:sass_sourcemap` filters improvements:

- Document `:sass` and `:sass_sourcemap` filters required `:css_path` option
- Document `:sass` capability of generating inline source maps