### PR TITLE
De-emphasize sidebar

### DIFF
--- a/content/assets/style/_article.scss
+++ b/content/assets/style/_article.scss
@@ -2,6 +2,10 @@ article {
   padding: 40px 0 0 0;
 
   @media (min-width: 720px) {
-    margin: 0 0 0 300px;
+    margin: 0 0 0 250px;
   }
+}
+
+.article-content {
+  padding: 30px;
 }

--- a/content/assets/style/_colors.scss
+++ b/content/assets/style/_colors.scss
@@ -27,6 +27,7 @@ $color-darkmode-mark:         hsl(0, 0, 0);
 
 // Derived colors
 
+$color-blue-hint:             mix($color-blue, $color-bg, 8%);
 $color-orange-quiet:          mix($color-orange, $color-bg, 10%);
 $color-bg-push:               mix($color-fg, $color-bg, 5%);
 $color-bg-pull:               mix($color-orange, $color-bg, 10%); // exception
@@ -37,6 +38,7 @@ $color-fg-60:                 mix($color-fg, $color-bg-push, 40%);
 $color-fg-80:                 mix($color-fg, $color-bg-push, 70%);
 $color-fg-95:                 mix($color-fg, $color-bg-push, 95%);
 
+$color-darkmode-blue-hint:    desaturate(mix($color-darkmode-blue, $color-darkmode-bg, 8%), 5%);
 $color-darkmode-orange-quiet: mix($color-darkmode-orange, $color-darkmode-bg, 10%);
 $color-darkmode-bg-push:      saturate(mix($color-darkmode-fg, $color-darkmode-bg, 5%), 5%);
 $color-darkmode-bg-pull:      mix($color-darkmode-bg, $color-darkmode-shadow, 50%); // exception
@@ -214,23 +216,33 @@ $color-darkmode-fg-95:        mix($color-darkmode-fg, $color-darkmode-bg-push, 9
 // Body
 
 @mixin page-bg-color {
-  background: $color-bg;
+  background: $color-blue-hint;
   @at-root.dark {
     // Special: this applies to the element itself
-    background: $color-darkmode-bg;
+    background: $color-darkmode-blue-hint;
   }
   @media (prefers-color-scheme: dark) {
-    background: $color-darkmode-bg;
+    background: $color-darkmode-blue-hint;
   }
 }
 
 @mixin page-top-border-color {
-  background: $color-orange;
+  border-color: $color-orange;
   @at-root .dark & {
-    background: $color-darkmode-orange;
+    border-color: $color-darkmode-orange;
   }
   @media (prefers-color-scheme: dark) {
-    background: $color-darkmode-orange;
+    border-color: $color-darkmode-orange;
+  }
+}
+
+.article-content {
+  background: $color-bg;
+  @at-root .dark & {
+    background: $color-darkmode-bg;
+  }
+  @media (prefers-color-scheme: dark) {
+    background: $color-darkmode-bg;
   }
 }
 
@@ -259,12 +271,12 @@ $color-darkmode-fg-95:        mix($color-darkmode-fg, $color-darkmode-bg-push, 9
 // Navigation
 
 @mixin nav-bg-color {
-  background: $color-bg-pull;
+  background: $color-bg;
   @at-root .dark & {
-    background: $color-darkmode-bg-pull;
+    background: $color-darkmode-bg;
   }
   @media (prefers-color-scheme: dark) {
-    background: $color-darkmode-bg-pull;
+    background: $color-darkmode-bg;
   }
 }
 

--- a/content/assets/style/_explanation.scss
+++ b/content/assets/style/_explanation.scss
@@ -7,7 +7,6 @@
 }
 
 .explanation-content {
-
   max-width: 960px;
 
   margin: 0 auto;

--- a/content/assets/style/_footer.scss
+++ b/content/assets/style/_footer.scss
@@ -39,7 +39,7 @@ footer {
   padding: 0;
 
   @media (min-width: 720px) {
-    padding: 0 20px 30px 320px;
+    padding: 0 20px 30px 275px;
   }
 
   @media (max-width: 719px) {

--- a/content/assets/style/_nav.scss
+++ b/content/assets/style/_nav.scss
@@ -1,6 +1,9 @@
 .nws-nav {
   @include nav-bg-color;
 
+  border-bottom: 2px solid;
+  @include page-top-border-color;
+
   margin: 0;
   padding: 0;
 

--- a/content/assets/style/_search.scss
+++ b/content/assets/style/_search.scss
@@ -1,10 +1,8 @@
 .nws-side__search {
   margin: 0 0 20px 0;
-  padding: 20px;
+  padding: 15px 0;
 
   z-index: 100;
-
-  @include sidebar-bg-color;
 
   > span {
     width: 100%;
@@ -21,7 +19,6 @@
     font-family: "Source Sans Pro";
     font-size: 16px;
 
-    @include search-bg-color;
     border: none;
     border-radius: 15px;
 

--- a/content/assets/style/_side.scss
+++ b/content/assets/style/_side.scss
@@ -7,7 +7,7 @@
     top: 60px;
     bottom: 0;
 
-    width: 260px;
+    width: 220px;
   }
 
   @media (max-width: 719px) {
@@ -55,15 +55,11 @@
 }
 
 .nws-side__content {
-  @include sidebar-bg-color;
-
   width: 100%;
-
-  padding: 20px;
 
   @media (min-width: 720px) {
     position: absolute;
-    top: 90px;
+    top: 70px;
     bottom: 0;
 
     overflow: auto;


### PR DESCRIPTION
This makes the sidebar blend more into the background, and pushes the main content more to the front.

* * *

![screenshot 2018-12-24 at 22 29 09](https://user-images.githubusercontent.com/6269/50406792-75587e00-07cb-11e9-8489-002ae784a6aa.png)

![screenshot 2018-12-24 at 22 28 51](https://user-images.githubusercontent.com/6269/50406793-77bad800-07cb-11e9-8357-b75ed5940b30.png)

* * *

![screenshot 2018-12-24 at 22 29 18](https://user-images.githubusercontent.com/6269/50406795-7be6f580-07cb-11e9-836c-d808565d4ec6.png)

![screenshot 2018-12-24 at 22 28 53](https://user-images.githubusercontent.com/6269/50406796-7e494f80-07cb-11e9-8d68-44df86ae92c2.png)
