### PR TITLE
Document unexpected descendant-or-self:: selector prefix behavior for the relativize_paths filter

### DIFF
--- a/content/doc/reference/filters.dmark
+++ b/content/doc/reference/filters.dmark
@@ -444,7 +444,7 @@ title: "Filters"
 
   #p In HTML, all %code{href} and %code{src} attributes will be relativized. In CSS, all %code{url()} references will be relativized.
 
-  #p To customize which attributes to normalize in (X)HTML, pass a list of XPath selectors to the %code{:select} option. For example, the following will only relativize paths if they occur within %code{href} attributes:
+  #p To customize which attributes to normalize in (X)HTML, pass a list of XPath selectors to the %code{:select} option. Selectors are prefixed with %code{descendant-or-self::} automatically. For example, the following will only relativize paths if they occur within %code{href} attributes on any element anywhere in the document:
 
   #listing[lang=ruby]
     filter :relativize_paths, type: :html, select: ['*/@href']


### PR DESCRIPTION
The documentation used to say to provide an XPath selector but your selector has to be written with the `//` prefix in mind. This behavior is really a bug (or a dialect of XPath) but changing it would break everyone’s sites so I’m documenting the unexpected behavior as a feature instead.